### PR TITLE
Xml commentdoc keywords

### DIFF
--- a/lexers/LexCPP.cxx
+++ b/lexers/LexCPP.cxx
@@ -1079,7 +1079,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 					}
 					if (!(IsASpace(sc.ch) || (sc.ch == 0))) {
 						sc.ChangeState(SCE_C_COMMENTDOCKEYWORDERROR|activitySet);
-					} else if (!keywords3.InList(s + 1)) {
+					} else if (!keywords3.InList(s + 1) && !keywords3.InList(s)) {
 						int subStyleCDKW = classifierDocKeyWords.ValueFor(s+1);
 						if (subStyleCDKW >= 0) {
 							sc.ChangeState(subStyleCDKW|activitySet);
@@ -1096,7 +1096,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 					} else {
 						sc.GetCurrentLowered(s, sizeof(s));
 					}
-					if (!keywords3.InList(s + 1)) {
+					if (!keywords3.InList(s)) {
 						int subStyleCDKW = classifierDocKeyWords.ValueFor(s + 1);
 						if (subStyleCDKW >= 0) {
 							sc.ChangeState(subStyleCDKW | activitySet);

--- a/lexers/LexCPP.cxx
+++ b/lexers/LexCPP.cxx
@@ -1,4 +1,4 @@
-// Scintilla source code edit control
+﻿// Scintilla source code edit control
 /** @file LexCPP.cxx
  ** Lexer for C++, C, Java, and JavaScript.
  ** Further folding features and configuration properties added by "Udo Lechner" <dlchnr(at)gmx(dot)net>
@@ -378,13 +378,13 @@ struct OptionsCPP {
 };
 
 const char *const cppWordLists[] = {
-            "Primary keywords and identifiers",
-            "Secondary keywords and identifiers",
-            "Documentation comment keywords",
-            "Global classes and typedefs",
-            "Preprocessor definitions",
-            "Task marker and error marker keywords",
-            nullptr,
+			"Primary keywords and identifiers",
+			"Secondary keywords and identifiers",
+			"Documentation comment keywords",
+			"Global classes and typedefs",
+			"Preprocessor definitions",
+			"Task marker and error marker keywords",
+			nullptr,
 };
 
 struct OptionSetCPP : public OptionSet<OptionsCPP> {
@@ -799,8 +799,8 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 
 	Sci_Position lineCurrent = styler.GetLine(startPos);
 	if ((MaskActive(initStyle) == SCE_C_PREPROCESSOR) ||
-      (MaskActive(initStyle) == SCE_C_COMMENTLINE) ||
-      (MaskActive(initStyle) == SCE_C_COMMENTLINEDOC)) {
+	  (MaskActive(initStyle) == SCE_C_COMMENTLINE) ||
+	  (MaskActive(initStyle) == SCE_C_COMMENTLINEDOC)) {
 		// Set continuationLine if last character of previous line is '\'
 		if (lineCurrent > 0) {
 			const Sci_Position endLinePrevious = styler.LineEnd(lineCurrent - 1);
@@ -923,7 +923,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if (!(setWord.Contains(sc.ch)
 				   || (sc.ch == '\'')
 				   || ((sc.ch == '+' || sc.ch == '-') && (sc.chPrev == 'e' || sc.chPrev == 'E' ||
-				                                          sc.chPrev == 'p' || sc.chPrev == 'P')))) {
+														  sc.chPrev == 'p' || sc.chPrev == 'P')))) {
 					sc.SetState(SCE_C_DEFAULT|activitySet);
 				}
 				break;
@@ -1032,6 +1032,10 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 						styleBeforeDCKeyword = SCE_C_COMMENTDOC;
 						sc.SetState(SCE_C_COMMENTDOCKEYWORD|activitySet);
 					}
+				} else if ((sc.ch == '<' && sc.chNext != '/')
+							|| (sc.ch == '/' && sc.chPrev == '<')) { // XML comment style
+					styleBeforeDCKeyword = SCE_C_COMMENTDOC;
+					sc.SetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
 				}
 				break;
 			case SCE_C_COMMENTLINE:
@@ -1051,6 +1055,10 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 						styleBeforeDCKeyword = SCE_C_COMMENTLINEDOC;
 						sc.SetState(SCE_C_COMMENTDOCKEYWORD|activitySet);
 					}
+				} else if ((sc.ch == '<' && sc.chNext != '/')
+							|| (sc.ch == '/' && sc.chPrev == '<')) { // XML comment style
+					styleBeforeDCKeyword = SCE_C_COMMENTLINEDOC;
+					sc.SetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
 				}
 				break;
 			case SCE_C_COMMENTDOCKEYWORD:
@@ -1062,7 +1070,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if (sc.ch == '[' || sc.ch == '{') {
 					seenDocKeyBrace = true;
 				} else if (!setDoxygen.Contains(sc.ch)
-				           && !(seenDocKeyBrace && (sc.ch == ',' || sc.ch == '.'))) {
+						   && !(seenDocKeyBrace && (sc.ch == ',' || sc.ch == '.'))) {
 					char s[100];
 					if (caseSensitive) {
 						sc.GetCurrent(s, sizeof(s));
@@ -1080,6 +1088,23 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 						}
 					}
 					sc.SetState(styleBeforeDCKeyword|activitySet);
+					seenDocKeyBrace = false;
+				} else if (sc.ch == '>') {
+					char s[100];
+					if (caseSensitive) {
+						sc.GetCurrent(s, sizeof(s));
+					} else {
+						sc.GetCurrentLowered(s, sizeof(s));
+					}
+					if (!keywords3.InList(s + 1)) {
+						int subStyleCDKW = classifierDocKeyWords.ValueFor(s + 1);
+						if (subStyleCDKW >= 0) {
+							sc.ChangeState(subStyleCDKW | activitySet);
+						} else {
+							sc.ChangeState(SCE_C_COMMENTDOCKEYWORDERROR | activitySet);
+						}
+					}
+					sc.SetState(styleBeforeDCKeyword | activitySet);
 					seenDocKeyBrace = false;
 				}
 				break;
@@ -1258,9 +1283,9 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 					sc.SetState(SCE_C_COMMENTLINE|activitySet);
 			} else if (sc.ch == '/'
 				   && (setOKBeforeRE.Contains(chPrevNonWhite)
-				       || followsReturnKeyword(sc, styler))
+					   || followsReturnKeyword(sc, styler))
 				   && (!setCouldBePostOp.Contains(chPrevNonWhite)
-				       || !FollowsPostfixOperator(sc, styler))) {
+					   || !FollowsPostfixOperator(sc, styler))) {
 				sc.SetState(SCE_C_REGEX|activitySet);	// JavaScript's RegEx
 				inRERange = false;
 			} else if (sc.ch == '\"') {

--- a/lexers/LexCPP.cxx
+++ b/lexers/LexCPP.cxx
@@ -1,4 +1,4 @@
-// Scintilla source code edit control
+﻿// Scintilla source code edit control
 /** @file LexCPP.cxx
  ** Lexer for C++, C, Java, and JavaScript.
  ** Further folding features and configuration properties added by "Udo Lechner" <dlchnr(at)gmx(dot)net>
@@ -1035,7 +1035,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if ((sc.ch == '<' && sc.chNext != '/')
 							|| (sc.ch == '/' && sc.chPrev == '<')) { // XML comment style
 					styleBeforeDCKeyword = SCE_C_COMMENTDOC;
-					sc.SetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
+					sc.ForwardSetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
 				}
 				break;
 			case SCE_C_COMMENTLINE:
@@ -1058,7 +1058,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if ((sc.ch == '<' && sc.chNext != '/')
 							|| (sc.ch == '/' && sc.chPrev == '<')) { // XML comment style
 					styleBeforeDCKeyword = SCE_C_COMMENTLINEDOC;
-					sc.SetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
+					sc.ForwardSetState(SCE_C_COMMENTDOCKEYWORD | activitySet);
 				}
 				break;
 			case SCE_C_COMMENTDOCKEYWORD:

--- a/lexers/LexCPP.cxx
+++ b/lexers/LexCPP.cxx
@@ -1,4 +1,4 @@
-﻿// Scintilla source code edit control
+// Scintilla source code edit control
 /** @file LexCPP.cxx
  ** Lexer for C++, C, Java, and JavaScript.
  ** Further folding features and configuration properties added by "Udo Lechner" <dlchnr(at)gmx(dot)net>
@@ -378,13 +378,13 @@ struct OptionsCPP {
 };
 
 const char *const cppWordLists[] = {
-			"Primary keywords and identifiers",
-			"Secondary keywords and identifiers",
-			"Documentation comment keywords",
-			"Global classes and typedefs",
-			"Preprocessor definitions",
-			"Task marker and error marker keywords",
-			nullptr,
+            "Primary keywords and identifiers",
+            "Secondary keywords and identifiers",
+            "Documentation comment keywords",
+            "Global classes and typedefs",
+            "Preprocessor definitions",
+            "Task marker and error marker keywords",
+            nullptr,
 };
 
 struct OptionSetCPP : public OptionSet<OptionsCPP> {
@@ -799,8 +799,8 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 
 	Sci_Position lineCurrent = styler.GetLine(startPos);
 	if ((MaskActive(initStyle) == SCE_C_PREPROCESSOR) ||
-	  (MaskActive(initStyle) == SCE_C_COMMENTLINE) ||
-	  (MaskActive(initStyle) == SCE_C_COMMENTLINEDOC)) {
+      (MaskActive(initStyle) == SCE_C_COMMENTLINE) ||
+      (MaskActive(initStyle) == SCE_C_COMMENTLINEDOC)) {
 		// Set continuationLine if last character of previous line is '\'
 		if (lineCurrent > 0) {
 			const Sci_Position endLinePrevious = styler.LineEnd(lineCurrent - 1);
@@ -923,7 +923,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if (!(setWord.Contains(sc.ch)
 				   || (sc.ch == '\'')
 				   || ((sc.ch == '+' || sc.ch == '-') && (sc.chPrev == 'e' || sc.chPrev == 'E' ||
-														  sc.chPrev == 'p' || sc.chPrev == 'P')))) {
+				                                          sc.chPrev == 'p' || sc.chPrev == 'P')))) {
 					sc.SetState(SCE_C_DEFAULT|activitySet);
 				}
 				break;
@@ -1070,7 +1070,7 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 				} else if (sc.ch == '[' || sc.ch == '{') {
 					seenDocKeyBrace = true;
 				} else if (!setDoxygen.Contains(sc.ch)
-						   && !(seenDocKeyBrace && (sc.ch == ',' || sc.ch == '.'))) {
+				           && !(seenDocKeyBrace && (sc.ch == ',' || sc.ch == '.'))) {
 					char s[100];
 					if (caseSensitive) {
 						sc.GetCurrent(s, sizeof(s));
@@ -1283,9 +1283,9 @@ void SCI_METHOD LexerCPP::Lex(Sci_PositionU startPos, Sci_Position length, int i
 					sc.SetState(SCE_C_COMMENTLINE|activitySet);
 			} else if (sc.ch == '/'
 				   && (setOKBeforeRE.Contains(chPrevNonWhite)
-					   || followsReturnKeyword(sc, styler))
+				       || followsReturnKeyword(sc, styler))
 				   && (!setCouldBePostOp.Contains(chPrevNonWhite)
-					   || !FollowsPostfixOperator(sc, styler))) {
+				       || !FollowsPostfixOperator(sc, styler))) {
 				sc.SetState(SCE_C_REGEX|activitySet);	// JavaScript's RegEx
 				inRERange = false;
 			} else if (sc.ch == '\"') {

--- a/test/examples/cpp/SciTE.properties
+++ b/test/examples/cpp/SciTE.properties
@@ -1,5 +1,6 @@
 lexer.*.cxx=cpp
 keywords.*.cxx=int let
 keywords2.*.cxx=
+keywords3.*.cxx=file
 lexer.cpp.track.preprocessor=1
 lexer.cpp.escape.sequence=1

--- a/test/examples/cpp/x.cxx
+++ b/test/examples/cpp/x.cxx
@@ -5,6 +5,14 @@
 	if (1);
 #endif
 
+/** @file LexCPP.cxx
+ <file>
+ <file />
+ <file/>
+ LexCPP.cxx.
+ </file>
+ **/
+
 #define M\
 
 \

--- a/test/examples/cpp/x.cxx
+++ b/test/examples/cpp/x.cxx
@@ -7,8 +7,7 @@
 
 /** @file LexCPP.cxx
  <file>
- <file />
- <file/>
+ <file >filename</file>
  LexCPP.cxx.
  </file>
  **/

--- a/test/examples/cpp/x.cxx.styled
+++ b/test/examples/cpp/x.cxx.styled
@@ -5,12 +5,11 @@
 	if (1);
 {9}#endif
 {0}
-{3}/** {18}@file{3} LexCPP.cxx
- <{18}file{3}>
- <{18}file{3} />
- <{18}file{3}/>
+{3}/** {17}@file{3} LexCPP.cxx
+ <{17}file{3}>
+ <{17}file{3} >filename</{17}file{3}>
  LexCPP.cxx.
- </{18}file{3}>
+ </{17}file{3}>
  **/{0}
 
 {9}#define M\

--- a/test/examples/cpp/x.cxx.styled
+++ b/test/examples/cpp/x.cxx.styled
@@ -5,6 +5,14 @@
 	if (1);
 {9}#endif
 {0}
+{3}/** {18}@file{3} LexCPP.cxx
+ <{18}file{3}>
+ <{18}file{3} />
+ <{18}file{3}/>
+ LexCPP.cxx.
+ </{18}file{3}>
+ **/{0}
+
 {9}#define M\
 
 {0}\


### PR DESCRIPTION
the cpp lexer is also used for e.g. C#, which usually uses XML styled comment doc keywords. This PR implements this.
Only the keywords are handled, no check for valid XML is done.