### PR TITLE
Improve batch syntax highlighting for variable expansion

### DIFF
--- a/lexers/LexBatch.cxx
+++ b/lexers/LexBatch.cxx
@@ -398,14 +398,53 @@ static void ColouriseBatchDoc(
 						// Reset Offset to re-process remainder of word
 						offset -= (wbl - 2);
 					// Check for Expanded Argument (%~...) / Variable (%%~...)
+					// Expanded Argument: %~[<path-operators>]<single digit>
+					// Expanded Variable: %%~[<path-operators>]<single identifier character>
+					// Path operators are exclusively alphabetic.
+					// Expanded arguments have a single digit at the end.
+					// Expanded variables have a single identifier character as variable name.
 					} else if (((wbl > 1) && (wordBuffer[1] == '~')) ||
 						((wbl > 2) && (wordBuffer[1] == '%') && (wordBuffer[2] == '~'))) {
 						// Check for External Command / Program
 						if (cmdLoc == offset - wbl) {
 							cmdLoc = offset - (wbl - wbo);
 						}
-						// Colorize Expanded Argument / Variable
-						styler.ColourTo(startLine + offset - 1 - (wbl - wbo), SCE_BAT_IDENTIFIER);
+						bool isArgument = (wordBuffer[1] == '~');
+						if (isArgument) {
+							Sci_PositionU expansionStopOffset = 2;
+							bool isValid = false;
+							for (; expansionStopOffset < wbl; expansionStopOffset++)
+							{
+								if (isArgument && Is0To9(wordBuffer[expansionStopOffset])) {
+									expansionStopOffset++;
+									isValid = true;
+									wbo = expansionStopOffset;
+									// Colorize Expanded Argument
+									styler.ColourTo(startLine + offset - 1 - (wbl - wbo), SCE_BAT_IDENTIFIER);
+									break;
+								}
+							}
+							if (!isValid) {
+								// not a valid expanded argument or variable
+								styler.ColourTo(startLine + offset - 1 - (wbl - wbo), SCE_BAT_DEFAULT);
+							}
+						// Expanded Variable
+						} else {
+							// start after ~
+							wbo = 3;
+							// Search to end of word for another % (can be a long path)
+							while ((wbo < wbl) &&
+								(wordBuffer[wbo] != '%')) {
+								wbo++;
+							}
+							if (wbo > 3) {
+								// Colorize Expanded Variable
+								styler.ColourTo(startLine + offset - 1 - (wbl - wbo), SCE_BAT_IDENTIFIER);
+							} else {
+								// not a valid expanded argument or variable
+								styler.ColourTo(startLine + offset - 1 - (wbl - wbo), SCE_BAT_DEFAULT);
+							}
+						}
 						// Reset Offset to re-process remainder of word
 						offset -= (wbl - wbo);
 					// Check for Environment Variable (%x...%)

--- a/test/examples/batch/x.bat
+++ b/test/examples/batch/x.bat
@@ -36,4 +36,10 @@ echo word ^
 1
 command
 
+:: Bug argument and variable expansion
+echo %~dp0123
+echo %%-~012
+echo %%~%%~-abcd
+FOR /F %%I in ("C:\Test\temp.txt") do echo %%~dI
+
 :END

--- a/test/examples/batch/x.bat.folded
+++ b/test/examples/batch/x.bat.folded
@@ -36,5 +36,11 @@
  0 400   0   1
  0 400   0   command
  0 400   0   
+ 0 400   0   :: Bug argument and variable expansion
+ 0 400   0   echo %~dp0123
+ 0 400   0   echo %%-~012
+ 0 400   0   echo %%~%%~-abcd
+ 0 400   0   FOR /F %%I in ("C:\Test\temp.txt") do echo %%~dI
+ 0 400   0   
  0 400   0   :END
  0 400   0   

--- a/test/examples/batch/x.bat.styled
+++ b/test/examples/batch/x.bat.styled
@@ -36,4 +36,10 @@ rem 'echo' is word=2, 'a' is default=0
 1
 {5}command{0}
 
+{1}:: Bug argument and variable expansion
+{2}echo{0} {6}%~dp0{0}123
+{2}echo{0} {6}%%-{0}~012
+{2}echo{0} %%~{6}%%~-abcd{0}
+{2}FOR{0} /F {6}%%I{2} in{0} ("C:\Test\temp.txt"){2} do echo{0} {6}%%~dI{0}
+
 {3}:END


### PR DESCRIPTION
Expanded arguments have a single digit at the end.

Fixes #4.