### PR TITLE
In YAML, treat a:b (without space) as text, not key-value pair

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,7 @@
 **.mms text
 **.tex text
 **.fs text
+**.yaml text
 **.md text
 **.txt text
 **.pch text

--- a/lexers/LexYAML.cxx
+++ b/lexers/LexYAML.cxx
@@ -35,6 +35,14 @@ static inline bool AtEOL(Accessor &styler, Sci_PositionU i) {
 		((styler[i] == '\r') && (styler.SafeGetCharAt(i + 1) != '\n'));
 }
 
+/**
+ * Check for space, tab, line feed, or carriage return.
+ * See YAML 1.2 spec sections 5.4. Line Break Characters and 5.5. White Space Characters.
+ */
+static constexpr bool IsWhiteSpaceOrEOL(char ch) noexcept {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+}
+
 static unsigned int SpaceCount(char* lineBuffer) {
 	if (lineBuffer == NULL)
 		return 0;
@@ -121,7 +129,7 @@ static void ColouriseYAMLLine(
 			styler.ColourTo(startLine + i - 1, SCE_YAML_DEFAULT);
 			styler.ColourTo(endPos, SCE_YAML_COMMENT);
 			return;
-		} else if (lineBuffer[i] == ':' && !bInQuotes) {
+		} else if (lineBuffer[i] == ':' && !bInQuotes && (IsWhiteSpaceOrEOL(lineBuffer[i + 1]) || i == lengthLine - 1)) {
 			styler.ColourTo(startLine + i - 1, SCE_YAML_IDENTIFIER);
 			styler.ColourTo(startLine + i, SCE_YAML_OPERATOR);
 			// Non-folding scalar

--- a/test/examples/yaml/SciTE.properties
+++ b/test/examples/yaml/SciTE.properties
@@ -1,0 +1,3 @@
+lexer.*.yaml=yaml
+keywords.*.yaml=true false yes no
+fold=1

--- a/test/examples/yaml/x.yaml
+++ b/test/examples/yaml/x.yaml
@@ -2,6 +2,8 @@
 
 key: value # comment
 
+colon:in:key: value
+
 hanging_value:
   value
 

--- a/test/examples/yaml/x.yaml
+++ b/test/examples/yaml/x.yaml
@@ -1,0 +1,10 @@
+# comment
+
+key: value # comment
+
+hanging_value:
+  value
+
+1: 1
+
+true: true

--- a/test/examples/yaml/x.yaml.folded
+++ b/test/examples/yaml/x.yaml.folded
@@ -2,6 +2,8 @@
  1 400   0   
  0 400   0   key: value # comment
  1 400   0   
+ 0 400   0   colon:in:key: value
+ 1 400   0   
  2 400   0 + hanging_value:
  0 402   0 |   value
  1 400   0   

--- a/test/examples/yaml/x.yaml.folded
+++ b/test/examples/yaml/x.yaml.folded
@@ -1,0 +1,11 @@
+ 0 400   0   # comment
+ 1 400   0   
+ 0 400   0   key: value # comment
+ 1 400   0   
+ 2 400   0 + hanging_value:
+ 0 402   0 |   value
+ 1 400   0   
+ 0 400   0   1: 1
+ 1 400   0   
+ 0 400   0   true: true
+ 0 400   0   

--- a/test/examples/yaml/x.yaml.styled
+++ b/test/examples/yaml/x.yaml.styled
@@ -1,0 +1,10 @@
+{1}# comment
+{0}
+{2}key{9}:{0} value {1}# comment
+{0}
+{2}hanging_value{9}:{0}
+  value
+
+{2}1{9}:{4} 1
+{0}
+{2}true{9}:{3} true

--- a/test/examples/yaml/x.yaml.styled
+++ b/test/examples/yaml/x.yaml.styled
@@ -2,6 +2,8 @@
 {0}
 {2}key{9}:{0} value {1}# comment
 {0}
+{2}colon:in:key{9}:{0} value
+
 {2}hanging_value{9}:{0}
   value
 


### PR DESCRIPTION
Currently `a:b` in YAML is parsed as if it's a key:value pair in a mapping, but instead it should be a text scalar.

Example:
```yaml
colon:in:key: value
```

Current styling:
```
{2}colon{9}:{0}in:key: value
```

Expected styling:
```
{2}colon:in:key{9}:{0} value
```

There are two commits in this merge request. The first commit adds a YAML test directory containing some simple test cases for the sake of having that structure there. The second commit is the actual bugfix, including the test case mentioned above. I haven't added an entry in LexillaHistory because I'm not sure if you prefer to write it yourself, but let me know if I should supply it as well.