### PR TITLE
LexHTML: fix handle PHP code embedded inside a JavaScript string

### DIFF
--- a/doc/LexillaHistory.html
+++ b/doc/LexillaHistory.html
@@ -568,6 +568,7 @@
       </tr><tr>
 	<td>Ivan Ustûžanin</td>
 	<td>Rainer Kottenhoff</td>
+	<td>feitoi</td>
     </tr>
     </table>
     <h2>Releases</h2>
@@ -603,6 +604,10 @@
 	For PHP, recognize start of comment after numeric literal.
 	<a href="https://github.com/ScintillaOrg/lexilla/issues/20">Issue #20</a>.
 	<a href="https://sourceforge.net/p/scintilla/bugs/2143/">Bug #2143</a>.
+	</li>
+	<li>
+	For PHP, recognize PHP code within JavaScript strings.
+	<a href="https://github.com/ScintillaOrg/lexilla/pull/27">Pull request #27</a>.
 	</li>
     </ul>
     <h3>

--- a/lexers/LexHTML.cxx
+++ b/lexers/LexHTML.cxx
@@ -1368,7 +1368,7 @@ void SCI_METHOD LexerHTML::Lex(Sci_PositionU startPos, Sci_Position length, int 
 		/////////////////////////////////////
 		// handle the start of PHP pre-processor = Non-HTML
 		else if ((state != SCE_H_ASPAT) &&
-		         !isStringState(state) &&
+		         !isPHPStringState(state) &&
 		         (state != SCE_HPHP_COMMENT) &&
 		         (state != SCE_HPHP_COMMENTLINE) &&
 		         (ch == '<') &&
@@ -1544,6 +1544,7 @@ void SCI_METHOD LexerHTML::Lex(Sci_PositionU startPos, Sci_Position length, int 
 				 (chPrev == '<') &&
 				 (ch == '!') &&
 				 (StateToPrint != SCE_H_CDATA) &&
+				 (!isStringState(StateToPrint)) &&
 				 (!IsCommentState(StateToPrint)) &&
 				 (!IsScriptCommentState(StateToPrint))) {
 			beforePreProc = state;

--- a/test/examples/hypertext/x.php
+++ b/test/examples/hypertext/x.php
@@ -5,3 +5,13 @@ echo "<!-- -->\n";
 /* ?> */
 ?>
 <strong>for</strong><b>if</b>
+<script>
+	alert("<?php echo "PHP" . ' Code'; ?>");
+	alert('<?= 'PHP' . "Code"; ?>');
+	var xml =
+	'<?xml version="1.0" encoding="iso-8859-1"?><SO_GL>' +
+	'<GLOBAL_LIST mode="complete"><NAME>SO_SINGLE_MULTIPLE_COMMAND_BUILDER</NAME>' +
+	'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM QI WEB BOOKING]]></LIST_VALUE></LIST_ELEMENT>' +
+	'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM *PCC]]></LIST_VALUE></LIST_ELEMENT>' +
+	'</GLOBAL_LIST></SO_GL>';
+</script>

--- a/test/examples/hypertext/x.php.folded
+++ b/test/examples/hypertext/x.php.folded
@@ -5,4 +5,14 @@
  0 402   0 | /* ?> */
  0 402   0 | ?>
  0 401   0 | <strong>for</strong><b>if</b>
+ 2 401   0 + <script>
+ 0 402   0 | 	alert("<?php echo "PHP" . ' Code'; ?>");
+ 0 402   0 | 	alert('<?= 'PHP' . "Code"; ?>');
+ 0 402   0 | 	var xml =
+ 0 402   0 | 	'<?xml version="1.0" encoding="iso-8859-1"?><SO_GL>' +
+ 0 402   0 | 	'<GLOBAL_LIST mode="complete"><NAME>SO_SINGLE_MULTIPLE_COMMAND_BUILDER</NAME>' +
+ 0 402   0 | 	'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM QI WEB BOOKING]]></LIST_VALUE></LIST_ELEMENT>' +
+ 0 402   0 | 	'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM *PCC]]></LIST_VALUE></LIST_ELEMENT>' +
+ 0 402   0 | 	'</GLOBAL_LIST></SO_GL>';
+ 0 402   0 | </script>
  0 401   0 | 

--- a/test/examples/hypertext/x.php.styled
+++ b/test/examples/hypertext/x.php.styled
@@ -5,3 +5,13 @@
 {124}/* ?> */{118}
 {18}?>{0}
 {1}<strong>{0}for{1}</strong><b>{0}if{1}</b>{0}
+{1}<script>{40}
+{41}	{46}alert{50}({48}"{18}<?php{118} {121}echo{118} {119}"PHP"{118} {127}.{118} {120}' Code'{127};{118} {18}?>{48}"{50});{41}
+	{46}alert{50}({49}'{18}<?{127}={118} {120}'PHP'{118} {127}.{118} {119}"Code"{127};{118} {18}?>{49}'{50});{41}
+	{47}var{41} {46}xml{41} {50}={41}
+	{49}'<?xml version="1.0" encoding="iso-8859-1"?><SO_GL>'{41} {50}+{41}
+	{49}'<GLOBAL_LIST mode="complete"><NAME>SO_SINGLE_MULTIPLE_COMMAND_BUILDER</NAME>'{41} {50}+{41}
+	{49}'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM QI WEB BOOKING]]></LIST_VALUE></LIST_ELEMENT>'{41} {50}+{41}
+	{49}'<LIST_ELEMENT><CODE>1</CODE><LIST_VALUE><![CDATA[RM *PCC]]></LIST_VALUE></LIST_ELEMENT>'{41} {50}+{41}
+	{49}'</GLOBAL_LIST></SO_GL>'{50};{41}
+{1}</script>{0}


### PR DESCRIPTION
The fix (commit 1574df52) to bug 767 just disabled handle PHP pre-processor inside a JavaScript string.
Undo the wrong fix and fix old bug 767 http://sourceforge.net/p/scintilla/bugs/767/