### PR TITLE
Matlab folding bugfix

### DIFF
--- a/lexers/LexMatlab.cxx
+++ b/lexers/LexMatlab.cxx
@@ -71,6 +71,8 @@ static int CheckKeywordFoldPoint(char *str) {
 		strcmp ("try", str) == 0 ||
 		strcmp ("do", str) == 0 ||
 		strcmp ("parfor", str) == 0 ||
+		strcmp ("classdef", str) == 0 ||
+		strcmp ("spmd", str) == 0 ||
 		strcmp ("function", str) == 0)
 		return 1;
 	if (strncmp("end", str, 3) == 0 ||

--- a/test/examples/matlab/ArgumentsBlock.m.matlab
+++ b/test/examples/matlab/ArgumentsBlock.m.matlab
@@ -1,0 +1,89 @@
+%% Correctly defined arguments block
+function y = foo (x)
+% Some comment here
+% And, maybe, here
+
+arguments
+    x (1,2) {mustBeReal(x)}
+end
+
+y = x*2;
+arguments = 1;
+y = y + arguments;
+end
+
+%% No arguments block, "arguments" is used 
+%  as a variable name (identifier)
+% Prevent arguments from folding with an identifier
+function y = foo (x)
+% Some comment here
+x = x + 1;
+arguments = 10;
+y = x + arguments;
+end
+
+% Prevent arguments from folding with a number
+function y = foo (x)
+4
+arguments = 10;
+y = x + arguments;
+end
+
+% With a double quote string
+function y = foo (x)
+"test"
+arguments = 10;
+y = x + arguments;
+end
+
+% With a string
+function y = foo (x)
+'test'
+arguments = 10;
+y = x + arguments;
+end
+
+% With a keyword
+function y = foo (x)
+if x == 0;
+    return 0;
+end
+arguments = 10;
+y = x + arguments;
+end
+
+% With an operator (illegal syntax)
+function y = foo (x)
+*
+arguments = 10;
+y = x + arguments;
+end
+
+% Arguments block is illegal in nested functions,
+% but lexer should process it anyway
+function y = foo (x)
+arguments
+    x (1,2) {mustBeReal(x)}
+end
+
+    function y = foo (x)
+    arguments
+        x (1,2) {mustBeReal(x)}
+    end
+    arguments = 5;
+    y = arguments + x;
+    end
+
+% Use as a variable, just in case
+arguments = 10;
+end
+
+% Erroneous use of arguments block
+function y = foo(x)
+% Some comment
+x = x + 1;
+arguments
+    x
+end
+y = x;
+end

--- a/test/examples/matlab/ArgumentsBlock.m.matlab.folded
+++ b/test/examples/matlab/ArgumentsBlock.m.matlab.folded
@@ -1,0 +1,89 @@
+ 0 400 400   %% Correctly defined arguments block
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | % Some comment here
+ 0 401 401 | % And, maybe, here
+ 1 401 401 | 
+ 2 401 402 + arguments
+ 0 402 402 |     x (1,2) {mustBeReal(x)}
+ 0 402 401 | end
+ 1 401 401 | 
+ 0 401 401 | y = x*2;
+ 0 401 401 | arguments = 1;
+ 0 401 401 | y = y + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   %% No arguments block, "arguments" is used 
+ 0 400 400   %  as a variable name (identifier)
+ 0 400 400   % Prevent arguments from folding with an identifier
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | % Some comment here
+ 0 401 401 | x = x + 1;
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % Prevent arguments from folding with a number
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | 4
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % With a double quote string
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | "test"
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % With a string
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | 'test'
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % With a keyword
+ 2 400 401 + function y = foo (x)
+ 2 401 402 + if x == 0;
+ 0 402 402 |     return 0;
+ 0 402 401 | end
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % With an operator (illegal syntax)
+ 2 400 401 + function y = foo (x)
+ 0 401 401 | *
+ 0 401 401 | arguments = 10;
+ 0 401 401 | y = x + arguments;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % Arguments block is illegal in nested functions,
+ 0 400 400   % but lexer should process it anyway
+ 2 400 401 + function y = foo (x)
+ 2 401 402 + arguments
+ 0 402 402 |     x (1,2) {mustBeReal(x)}
+ 0 402 401 | end
+ 1 401 401 | 
+ 2 401 402 +     function y = foo (x)
+ 2 402 403 +     arguments
+ 0 403 403 |         x (1,2) {mustBeReal(x)}
+ 0 403 402 |     end
+ 0 402 402 |     arguments = 5;
+ 0 402 402 |     y = arguments + x;
+ 0 402 401 |     end
+ 1 401 401 | 
+ 0 401 401 | % Use as a variable, just in case
+ 0 401 401 | arguments = 10;
+ 0 401 400 | end
+ 1 400 400   
+ 0 400 400   % Erroneous use of arguments block
+ 2 400 401 + function y = foo(x)
+ 0 401 401 | % Some comment
+ 0 401 401 | x = x + 1;
+ 0 401 401 | arguments
+ 0 401 401 |     x
+ 0 401 400 | end
+ 0 400 400   y = x;
+ 0 400 3ff   end

--- a/test/examples/matlab/ArgumentsBlock.m.matlab.styled
+++ b/test/examples/matlab/ArgumentsBlock.m.matlab.styled
@@ -1,0 +1,89 @@
+{1}%% Correctly defined arguments block{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{1}% Some comment here{0}
+{1}% And, maybe, here{0}
+
+{4}arguments{0}
+    {7}x{0} {6}({3}1{6},{3}2{6}){0} {6}{{7}mustBeReal{6}({7}x{6})}{0}
+{4}end{0}
+
+{7}y{0} {6}={0} {7}x{6}*{3}2{6};{0}
+{7}arguments{0} {6}={0} {3}1{6};{0}
+{7}y{0} {6}={0} {7}y{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}%% No arguments block, "arguments" is used {0}
+{1}%  as a variable name (identifier){0}
+{1}% Prevent arguments from folding with an identifier{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{1}% Some comment here{0}
+{7}x{0} {6}={0} {7}x{0} {6}+{0} {3}1{6};{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% Prevent arguments from folding with a number{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{3}4{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% With a double quote string{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{8}"test"{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% With a string{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{5}'test'{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% With a keyword{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{4}if{0} {7}x{0} {6}=={0} {3}0{6};{0}
+    {4}return{0} {3}0{6};{0}
+{4}end{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% With an operator (illegal syntax){0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{6}*{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{7}y{0} {6}={0} {7}x{0} {6}+{0} {7}arguments{6};{0}
+{4}end{0}
+
+{1}% Arguments block is illegal in nested functions,{0}
+{1}% but lexer should process it anyway{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+{4}arguments{0}
+    {7}x{0} {6}({3}1{6},{3}2{6}){0} {6}{{7}mustBeReal{6}({7}x{6})}{0}
+{4}end{0}
+
+    {4}function{0} {7}y{0} {6}={0} {7}foo{0} {6}({7}x{6}){0}
+    {4}arguments{0}
+        {7}x{0} {6}({3}1{6},{3}2{6}){0} {6}{{7}mustBeReal{6}({7}x{6})}{0}
+    {4}end{0}
+    {7}arguments{0} {6}={0} {3}5{6};{0}
+    {7}y{0} {6}={0} {7}arguments{0} {6}+{0} {7}x{6};{0}
+    {4}end{0}
+
+{1}% Use as a variable, just in case{0}
+{7}arguments{0} {6}={0} {3}10{6};{0}
+{4}end{0}
+
+{1}% Erroneous use of arguments block{0}
+{4}function{0} {7}y{0} {6}={0} {7}foo{6}({7}x{6}){0}
+{1}% Some comment{0}
+{7}x{0} {6}={0} {7}x{0} {6}+{0} {3}1{6};{0}
+{7}arguments{0}
+    {7}x{0}
+{4}end{0}
+{7}y{0} {6}={0} {7}x{6};{0}
+{4}end

--- a/test/examples/matlab/FoldPoints.m.matlab
+++ b/test/examples/matlab/FoldPoints.m.matlab
@@ -1,0 +1,48 @@
+% All the exaples here should yeild folding
+
+classdef
+    % Some code
+end
+
+for
+    % Some code
+end
+
+function
+    % Some code
+end
+
+if
+    % Some code
+elseif
+    % Some code
+else
+    % Some code
+end
+
+parfor
+    % Some code
+end
+
+spmd
+    % Some code
+end
+
+switch
+    case
+        % Some code
+    case
+        % Some code
+    otherwise
+        % Some code
+end
+
+try
+    % Some code
+catch
+    % Some code
+end
+
+while
+    % Some code
+end

--- a/test/examples/matlab/FoldPoints.m.matlab.folded
+++ b/test/examples/matlab/FoldPoints.m.matlab.folded
@@ -1,0 +1,49 @@
+ 0 400 400   % All the exaples here should yeild folding
+ 1 400 400   
+ 2 400 401 + classdef
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + for
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + function
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + if
+ 0 401 401 |     % Some code
+ 0 401 401 | elseif
+ 0 401 401 |     % Some code
+ 0 401 401 | else
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + parfor
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + spmd
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + switch
+ 0 401 401 |     case
+ 0 401 401 |         % Some code
+ 0 401 401 |     case
+ 0 401 401 |         % Some code
+ 0 401 401 |     otherwise
+ 0 401 401 |         % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + try
+ 0 401 401 |     % Some code
+ 0 401 401 | catch
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   
+ 2 400 401 + while
+ 0 401 401 |     % Some code
+ 0 401 400 | end
+ 1 400 400   

--- a/test/examples/matlab/FoldPoints.m.matlab.styled
+++ b/test/examples/matlab/FoldPoints.m.matlab.styled
@@ -1,0 +1,48 @@
+{1}% All the exaples here should yeild folding{0}
+
+{4}classdef{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}for{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}function{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}if{0}
+    {1}% Some code{0}
+{4}elseif{0}
+    {1}% Some code{0}
+{4}else{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}parfor{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}spmd{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}switch{0}
+    {4}case{0}
+        {1}% Some code{0}
+    {4}case{0}
+        {1}% Some code{0}
+    {4}otherwise{0}
+        {1}% Some code{0}
+{4}end{0}
+
+{4}try{0}
+    {1}% Some code{0}
+{4}catch{0}
+    {1}% Some code{0}
+{4}end{0}
+
+{4}while{0}
+    {1}% Some code{0}
+{4}end{0}

--- a/test/examples/matlab/SciTE.properties
+++ b/test/examples/matlab/SciTE.properties
@@ -1,5 +1,5 @@
 lexer.*.matlab=matlab
-keywords.*.matlab=end for global if
+keywords.*.matlab=end for global if break case catch classdef continue else elseif function otherwise parfor persistent return spmd switch try while
 
 lexer.*.octave=octave
 keywords.*.octave=end for global if

--- a/test/examples/matlab/SciTE.properties
+++ b/test/examples/matlab/SciTE.properties
@@ -1,7 +1,5 @@
 lexer.*.matlab=matlab
 keywords.*.matlab=end for global if break case catch classdef continue else elseif function otherwise parfor persistent return spmd switch try while
-if $(= $(FileNameExt);ArgumentsBlock.m.matlab)
-    testlexers.per.line.disable=1
 
 lexer.*.octave=octave
 keywords.*.octave=end for global if

--- a/test/examples/matlab/SciTE.properties
+++ b/test/examples/matlab/SciTE.properties
@@ -1,5 +1,7 @@
 lexer.*.matlab=matlab
 keywords.*.matlab=end for global if break case catch classdef continue else elseif function otherwise parfor persistent return spmd switch try while
+if $(= $(FileNameExt);ArgumentsBlock.m.matlab)
+    testlexers.per.line.disable=1
 
 lexer.*.octave=octave
 keywords.*.octave=end for global if


### PR DESCRIPTION
Lexilla doesn't know a couple of MATLAB's keywords, so it cannot do the proper folding when these keywords are used.  
This PR adds the absent keywords into the MATLAB lexer.  
It also includes the code processing the "arguments" keyword edge case.