### PR TITLE
Matlab class syntax improvement

### DIFF
--- a/lexers/LexMatlab.cxx
+++ b/lexers/LexMatlab.cxx
@@ -22,6 +22,9 @@
  **
  ** Changes by John Donoghue 2017/01/18
  **   - update matlab block comment detection
+ **
+ ** Changes by Andrey Smolyakov 2022/04/15
+ **   - add support for "arguments" block and class definition syntax
  **/
 // Copyright 1998-2001 by Neil Hodgson <neilh@scintilla.org>
 // The License.txt file describes the conditions under which this software may be distributed.
@@ -74,6 +77,9 @@ static int CheckKeywordFoldPoint(char *str) {
 		strcmp ("classdef", str) == 0 ||
 		strcmp ("spmd", str) == 0 ||
 		strcmp ("arguments", str) == 0 ||
+		strcmp ("methods", str) == 0 ||
+		strcmp ("properties", str) == 0 ||
+		strcmp ("events", str) == 0 ||
 		strcmp ("function", str) == 0)
 		return 1;
 	if (strncmp("end", str, 3) == 0 ||
@@ -92,9 +98,28 @@ static bool IsSpaceToEOL(Sci_Position startPos, Accessor &styler) {
 	return true;
 }
 
-#define MATLAB_STATE_FLAGS_OFFSET        8
+#define MATLAB_STATE_FOLD_LVL_OFFSET     8
+#define MATLAB_STATE_FOLD_LVL_MASK       (0xFF00)
+#define MATLAB_STATE_FLAGS_OFFSET        16
+#define MATLAB_STATE_COMM_DEPTH_OFFSET   0
 #define MATLAB_STATE_COMM_DEPTH_MASK     (0xFF)
 #define MATLAB_STATE_EXPECTING_ARG_BLOCK (1 << MATLAB_STATE_FLAGS_OFFSET)
+#define MATLAB_STATE_IN_CLASS_SCOPE      (1 <<(MATLAB_STATE_FLAGS_OFFSET+1))
+
+static int ComposeLineState(int commentDepth,
+							int foldingLevel,
+							int expectingArgumentsBlock,
+							int inClassScope) {
+
+	return  ((commentDepth << MATLAB_STATE_COMM_DEPTH_OFFSET)
+				& MATLAB_STATE_COMM_DEPTH_MASK)					|
+			((foldingLevel << MATLAB_STATE_FOLD_LVL_OFFSET)
+				& MATLAB_STATE_FOLD_LVL_MASK)					|
+			(expectingArgumentsBlock
+				& MATLAB_STATE_EXPECTING_ARG_BLOCK)				|
+			(inClassScope
+				& MATLAB_STATE_IN_CLASS_SCOPE);
+}
 
 static void ColouriseMatlabOctaveDoc(
             Sci_PositionU startPos, Sci_Position length, int initStyle,
@@ -123,6 +148,10 @@ static void ColouriseMatlabOctaveDoc(
 	// We've just seen "function" keyword, so now we may expect the "arguments"
 	// keyword opening the corresponding code block
 	int expectingArgumentsBlock = 0;
+	// Current line's folding level
+	int foldingLevel = 0;
+	// Current line in in class scope
+	int inClassScope = 0;
 
 	// use the line state of each line to store the block comment depth
 	Sci_Position curLine = styler.GetLine(startPos);
@@ -130,8 +159,12 @@ static void ColouriseMatlabOctaveDoc(
 	// Restore the previous line's state, if there was such a line
 	if (curLine > 0) {
 		int prevState = styler.GetLineState(curLine-1);
-		commentDepth = prevState & MATLAB_STATE_COMM_DEPTH_MASK;
+		commentDepth = (prevState & MATLAB_STATE_COMM_DEPTH_MASK)
+							>> MATLAB_STATE_COMM_DEPTH_OFFSET;
+		foldingLevel = (prevState & MATLAB_STATE_FOLD_LVL_MASK)
+							>> MATLAB_STATE_FOLD_LVL_OFFSET;
 		expectingArgumentsBlock = prevState & MATLAB_STATE_EXPECTING_ARG_BLOCK;
+		inClassScope = prevState & MATLAB_STATE_IN_CLASS_SCOPE;
 	}
 
 
@@ -142,7 +175,8 @@ static void ColouriseMatlabOctaveDoc(
 		if(sc.atLineStart) {
 			// set the line state to the current commentDepth
 			curLine = styler.GetLine(sc.currentPos);
-			styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+			styler.SetLineState(curLine, ComposeLineState(
+				commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 
 			// reset the column to 0, nonSpace to -1 (not set)
 			column = 0;
@@ -159,8 +193,14 @@ static void ColouriseMatlabOctaveDoc(
 					(sc.state != SCE_MATLAB_COMMENT) &&
 					(sc.state != SCE_MATLAB_DEFAULT)) {
 				expectingArgumentsBlock = 0;
-				styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+				styler.SetLineState(curLine, ComposeLineState(
+					commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 			}
+		}
+		
+		// We've just left the class scope
+		if ((foldingLevel ==0) && inClassScope) {
+			inClassScope = 0;
 		}
 
 		// save the column position of first non space character in a line
@@ -191,37 +231,58 @@ static void ColouriseMatlabOctaveDoc(
 			if (!isalnum(sc.ch) && sc.ch != '_') {
 				char s[100];
 				sc.GetCurrent(s, sizeof(s));
+				bool notKeyword = false;
+				transpose = false;
 
 				if (keywords.InList(s)) {
 					if (strcmp ("end", s) == 0 && allow_end_op) {
 						sc.ChangeState(SCE_MATLAB_NUMBER);
-					}
-					// Need this flag to handle "arguments" block correctly
-					if (strcmp("function", s) == 0) {
+						notKeyword = true;
+					} else if (strcmp("function", s) == 0) {
+						// Need this flag to handle "arguments" block correctly
 						funcDeclarationLine = true;
 						expectingArgumentsBlock = ismatlab ? MATLAB_STATE_EXPECTING_ARG_BLOCK : 0;
+					} else if (strcmp("classdef", s) == 0) {
+						// Need this flag to process "events", "methods" and "properties" blocks
+						inClassScope = MATLAB_STATE_IN_CLASS_SCOPE;
 					}
 					expectingArgumentsBlock = funcDeclarationLine ? expectingArgumentsBlock : 0;
-					sc.SetState(SCE_MATLAB_DEFAULT);
-					transpose = false;
 				} else {
 					// "arguments" is a keyword here, despite not being in the keywords list
 					if (expectingArgumentsBlock && (strcmp("arguments", s) == 0)) {
 						// No need to expect another arguments block
 						expectingArgumentsBlock = 0;
-						sc.SetState(SCE_MATLAB_DEFAULT);
-						transpose = false;
 					} else {
-						// Found an identifier after the fun declaration
+						// Found an identifier or a keyword after the function declaration
 						// No need to wait for the arguments block anymore
 						expectingArgumentsBlock = funcDeclarationLine ? expectingArgumentsBlock : 0;
-						sc.ChangeState(SCE_MATLAB_IDENTIFIER);
-						sc.SetState(SCE_MATLAB_DEFAULT);
-						transpose = true;
+						
+						// "properties", "methods" and "events" are not keywords if they're declared
+						// inside some function in methods block
+						// To avoid tracking possible nested functions scopes, lexer considers everything
+						// beyond level 2 of folding to be in a scope of some function declared in the
+						// methods block. It is ok for the valid syntax: classes can only be declared in
+						// a separate file, function - only in methods block. However, in case of the invalid
+						// syntax lexer may erroneously ignore a keyword.
+						if (!((inClassScope) && (foldingLevel <= 2) && (
+								strcmp("properties", s) == 0 || 
+								strcmp("methods",    s) == 0 ||
+								strcmp("events",     s) == 0 ))) {
+							sc.ChangeState(SCE_MATLAB_IDENTIFIER);
+							transpose = true;
+							notKeyword = true;
+						}
 					}
 				}
+				
+				sc.SetState(SCE_MATLAB_DEFAULT);
+				if (!notKeyword) {
+					foldingLevel += CheckKeywordFoldPoint(s);
+				}
 			}
-			styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+			
+			styler.SetLineState(curLine, ComposeLineState(
+				commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 		} else if (sc.state == SCE_MATLAB_NUMBER) {
 			if (!isdigit(sc.ch) && sc.ch != '.'
 			        && !(sc.ch == 'e' || sc.ch == 'E')
@@ -256,7 +317,8 @@ static void ColouriseMatlabOctaveDoc(
 				if(commentDepth > 0) commentDepth --;
 
 				curLine = styler.GetLine(sc.currentPos);
-				styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+				styler.SetLineState(curLine, ComposeLineState(
+					commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 				sc.Forward();
 
 				if (commentDepth == 0) {
@@ -267,7 +329,8 @@ static void ColouriseMatlabOctaveDoc(
 				commentDepth ++;
 
 				curLine = styler.GetLine(sc.currentPos);
-				styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+				styler.SetLineState(curLine, ComposeLineState(
+					commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 				sc.Forward();
 				transpose = false;
 
@@ -290,7 +353,8 @@ static void ColouriseMatlabOctaveDoc(
 					}
 				}
 				curLine = styler.GetLine(sc.currentPos);
-				styler.SetLineState(curLine, commentDepth | expectingArgumentsBlock);
+				styler.SetLineState(curLine, ComposeLineState(
+					commentDepth, foldingLevel, expectingArgumentsBlock, inClassScope));
 				sc.SetState(SCE_MATLAB_COMMENT);
 			} else if (sc.ch == '!' && sc.chNext != '=' ) {
 				if(ismatlab) {

--- a/test/examples/matlab/ClassDefinition.m.matlab
+++ b/test/examples/matlab/ClassDefinition.m.matlab
@@ -1,0 +1,74 @@
+classdef Foo < handle
+
+    % A couple of properties blocks
+    properties (SetAccess = private)
+        Var1
+        Var2
+    end
+
+    properties
+        Var3
+        Var4
+    end
+
+    methods (Static)
+        function y = f1(x)
+            % events, properties and methods are the valid idenifiers
+            % in the function scope
+            events = 1;
+            properties = 2;
+            y = x + events * properties;
+        end
+
+        % Any of these words are also valid functions' names inside
+        % methods block
+        function y = events(x)
+            
+            arguments
+                x {mustBeNegative}
+            end
+
+            y = f2(x)*100;
+            function b = f2(a)
+                b = a + 5;
+            end
+        end
+    end
+
+    % Example events block
+    events
+        Event1
+        Event2
+    end
+end
+
+
+% Now, let's break some stuff
+classdef Bar
+
+    properties
+        % Though MATLAB won't execute such a code, events, properties
+        % and methods are keywords here, because we're still in the class scope
+        events
+        end
+
+        methods
+        end        
+    end
+    
+    % Not allowed in MATLAB, but, technically, we're still in the class scope
+    if condition1
+        if condition2
+            % Though we're in the class scope, lexel will recognize no
+            % keywords here: to avoid the neccessaty to track nested scopes,
+            % it just considers everything beyond level 2 of folding to be
+            % a function scope
+            methods
+            events
+            properties
+        end
+    end
+
+
+end
+

--- a/test/examples/matlab/ClassDefinition.m.matlab.folded
+++ b/test/examples/matlab/ClassDefinition.m.matlab.folded
@@ -1,0 +1,75 @@
+ 2 400 401 + classdef Foo < handle
+ 1 401 401 | 
+ 0 401 401 |     % A couple of properties blocks
+ 2 401 402 +     properties (SetAccess = private)
+ 0 402 402 |         Var1
+ 0 402 402 |         Var2
+ 0 402 401 |     end
+ 1 401 401 | 
+ 2 401 402 +     properties
+ 0 402 402 |         Var3
+ 0 402 402 |         Var4
+ 0 402 401 |     end
+ 1 401 401 | 
+ 2 401 402 +     methods (Static)
+ 2 402 403 +         function y = f1(x)
+ 0 403 403 |             % events, properties and methods are the valid idenifiers
+ 0 403 403 |             % in the function scope
+ 0 403 403 |             events = 1;
+ 0 403 403 |             properties = 2;
+ 0 403 403 |             y = x + events * properties;
+ 0 403 402 |         end
+ 1 402 402 | 
+ 0 402 402 |         % Any of these words are also valid functions' names inside
+ 0 402 402 |         % methods block
+ 2 402 403 +         function y = events(x)
+ 1 403 403 |             
+ 2 403 404 +             arguments
+ 0 404 404 |                 x {mustBeNegative}
+ 0 404 403 |             end
+ 1 403 403 | 
+ 0 403 403 |             y = f2(x)*100;
+ 2 403 404 +             function b = f2(a)
+ 0 404 404 |                 b = a + 5;
+ 0 404 403 |             end
+ 0 403 402 |         end
+ 0 402 401 |     end
+ 1 401 401 | 
+ 0 401 401 |     % Example events block
+ 2 401 402 +     events
+ 0 402 402 |         Event1
+ 0 402 402 |         Event2
+ 0 402 401 |     end
+ 0 401 400 | end
+ 1 400 400   
+ 1 400 400   
+ 0 400 400   % Now, let's break some stuff
+ 2 400 401 + classdef Bar
+ 1 401 401 | 
+ 2 401 402 +     properties
+ 0 402 402 |         % Though MATLAB won't execute such a code, events, properties
+ 0 402 402 |         % and methods are keywords here, because we're still in the class scope
+ 2 402 403 +         events
+ 0 403 402 |         end
+ 1 402 402 | 
+ 2 402 403 +         methods
+ 0 403 402 |         end        
+ 0 402 401 |     end
+ 1 401 401 |     
+ 0 401 401 |     % Not allowed in MATLAB, but, technically, we're still in the class scope
+ 2 401 402 +     if condition1
+ 2 402 403 +         if condition2
+ 0 403 403 |             % Though we're in the class scope, lexel will recognize no
+ 0 403 403 |             % keywords here: to avoid the neccessaty to track nested scopes,
+ 0 403 403 |             % it just considers everything beyond level 2 of folding to be
+ 0 403 403 |             % a function scope
+ 0 403 403 |             methods
+ 0 403 403 |             events
+ 0 403 403 |             properties
+ 0 403 402 |         end
+ 0 402 401 |     end
+ 1 401 401 | 
+ 1 401 401 | 
+ 0 401 400 | end
+ 1 400 400   
+ 1 400 400   

--- a/test/examples/matlab/ClassDefinition.m.matlab.styled
+++ b/test/examples/matlab/ClassDefinition.m.matlab.styled
@@ -1,0 +1,74 @@
+{4}classdef{0} {7}Foo{0} {6}<{0} {7}handle{0}
+
+    {1}% A couple of properties blocks{0}
+    {4}properties{0} {6}({7}SetAccess{0} {6}={0} {7}private{6}){0}
+        {7}Var1{0}
+        {7}Var2{0}
+    {4}end{0}
+
+    {4}properties{0}
+        {7}Var3{0}
+        {7}Var4{0}
+    {4}end{0}
+
+    {4}methods{0} {6}({7}Static{6}){0}
+        {4}function{0} {7}y{0} {6}={0} {7}f1{6}({7}x{6}){0}
+            {1}% events, properties and methods are the valid idenifiers{0}
+            {1}% in the function scope{0}
+            {7}events{0} {6}={0} {3}1{6};{0}
+            {7}properties{0} {6}={0} {3}2{6};{0}
+            {7}y{0} {6}={0} {7}x{0} {6}+{0} {7}events{0} {6}*{0} {7}properties{6};{0}
+        {4}end{0}
+
+        {1}% Any of these words are also valid functions' names inside{0}
+        {1}% methods block{0}
+        {4}function{0} {7}y{0} {6}={0} {7}events{6}({7}x{6}){0}
+            
+            {4}arguments{0}
+                {7}x{0} {6}{{7}mustBeNegative{6}}{0}
+            {4}end{0}
+
+            {7}y{0} {6}={0} {7}f2{6}({7}x{6})*{3}100{6};{0}
+            {4}function{0} {7}b{0} {6}={0} {7}f2{6}({7}a{6}){0}
+                {7}b{0} {6}={0} {7}a{0} {6}+{0} {3}5{6};{0}
+            {4}end{0}
+        {4}end{0}
+    {4}end{0}
+
+    {1}% Example events block{0}
+    {4}events{0}
+        {7}Event1{0}
+        {7}Event2{0}
+    {4}end{0}
+{4}end{0}
+
+
+{1}% Now, let's break some stuff{0}
+{4}classdef{0} {7}Bar{0}
+
+    {4}properties{0}
+        {1}% Though MATLAB won't execute such a code, events, properties{0}
+        {1}% and methods are keywords here, because we're still in the class scope{0}
+        {4}events{0}
+        {4}end{0}
+
+        {4}methods{0}
+        {4}end{0}        
+    {4}end{0}
+    
+    {1}% Not allowed in MATLAB, but, technically, we're still in the class scope{0}
+    {4}if{0} {7}condition1{0}
+        {4}if{0} {7}condition2{0}
+            {1}% Though we're in the class scope, lexel will recognize no{0}
+            {1}% keywords here: to avoid the neccessaty to track nested scopes,{0}
+            {1}% it just considers everything beyond level 2 of folding to be{0}
+            {1}% a function scope{0}
+            {7}methods{0}
+            {7}events{0}
+            {7}properties{0}
+        {4}end{0}
+    {4}end{0}
+
+
+{4}end{0}
+


### PR DESCRIPTION
@zufuliu suggested adding support for the classes definition syntax in the discussion of PR #70. This PR contains a proposed solution.  
It works fine with the correct syntax but employs a little hack: it doesn't recognize function scopes to avoid storing too much data in the line state integer. Instead, it just considers everything within a folding level beyond the 2nd to be a function's scope. This consideration  may lead to the erroneous neglect of some keywords (there's an example in the proposed test). However, such a problem can occur only in a file with invalid syntax, so I think it's not really an issue.