### PR TITLE
Cosmetics in LexMatlab.cxx

### DIFF
--- a/lexers/LexMatlab.cxx
+++ b/lexers/LexMatlab.cxx
@@ -322,7 +322,7 @@ static void ColouriseMatlabOctaveDoc(
 				sc.Forward();
 
 				if (commentDepth == 0) {
-					sc.ForwardSetState(SCE_D_DEFAULT);
+					sc.ForwardSetState(SCE_MATLAB_DEFAULT);
 					transpose = false;
 				}
 			} else if( IsCommentChar(sc.ch) && sc.chNext == '{' && nonSpaceColumn == column && IsSpaceToEOL(sc.currentPos+2, styler)) {


### PR DESCRIPTION
Cosmetics: use SCE_MATLAB_DEFAULT instead of SCE_D_DEFAULT