### PR TITLE
VisualProlog: Add options to support also other Prolog dialects

### DIFF
--- a/lexers/LexVisualProlog.cxx
+++ b/lexers/LexVisualProlog.cxx
@@ -48,7 +48,9 @@ using namespace Lexilla;
 
 // Options used for LexerVisualProlog
 struct OptionsVisualProlog {
+    bool verbatimStrings;
     OptionsVisualProlog() {
+        verbatimStrings = true;
     }
 };
 
@@ -62,6 +64,8 @@ static const char *const visualPrologWordLists[] = {
 
 struct OptionSetVisualProlog : public OptionSet<OptionsVisualProlog> {
     OptionSetVisualProlog() {
+        DefineProperty("lexer.visualprolog.verbatim.strings", &OptionsVisualProlog::verbatimStrings,
+            "Set to 0 to disable highlighting verbatim strings using '@'.");
         DefineWordListSets(visualPrologWordLists);
     }
 };
@@ -421,7 +425,7 @@ void SCI_METHOD LexerVisualProlog::Lex(Sci_PositionU startPos, Sci_Position leng
 
         // Determine if a new state should be entered.
         if (sc.state == SCE_VISUALPROLOG_DEFAULT) {
-            if (sc.Match('@') && isOpenStringVerbatim(sc.chNext, closingQuote)) {
+            if (options.verbatimStrings && sc.Match('@') && isOpenStringVerbatim(sc.chNext, closingQuote)) {
                 sc.SetState(SCE_VISUALPROLOG_STRING_VERBATIM);
                 sc.Forward();
             } else if (IsADigit(sc.ch) || (sc.Match('.') && IsADigit(sc.chNext))) {
@@ -446,7 +450,8 @@ void SCI_METHOD LexerVisualProlog::Lex(Sci_PositionU startPos, Sci_Position leng
                 sc.SetState(SCE_VISUALPROLOG_STRING);
             } else if (sc.Match('#')) {
                 sc.SetState(SCE_VISUALPROLOG_KEY_DIRECTIVE);
-            } else if (isoperator(static_cast<char>(sc.ch)) || sc.Match('\\')) {
+            } else if (isoperator(static_cast<char>(sc.ch)) || sc.Match('\\') ||
+                (!options.verbatimStrings && sc.Match('@'))) {
                 sc.SetState(SCE_VISUALPROLOG_OPERATOR);
             }
         }

--- a/lexers/LexVisualProlog.cxx
+++ b/lexers/LexVisualProlog.cxx
@@ -49,8 +49,10 @@ using namespace Lexilla;
 // Options used for LexerVisualProlog
 struct OptionsVisualProlog {
     bool verbatimStrings;
+    bool backQuotedStrings;
     OptionsVisualProlog() {
         verbatimStrings = true;
+        backQuotedStrings = false;
     }
 };
 
@@ -66,6 +68,8 @@ struct OptionSetVisualProlog : public OptionSet<OptionsVisualProlog> {
     OptionSetVisualProlog() {
         DefineProperty("lexer.visualprolog.verbatim.strings", &OptionsVisualProlog::verbatimStrings,
             "Set to 0 to disable highlighting verbatim strings using '@'.");
+        DefineProperty("lexer.visualprolog.backquoted.strings", &OptionsVisualProlog::backQuotedStrings,
+            "Set to 1 to enable using back quotes (``) to delimit strings.");
         DefineWordListSets(visualPrologWordLists);
     }
 };
@@ -447,6 +451,9 @@ void SCI_METHOD LexerVisualProlog::Lex(Sci_PositionU startPos, Sci_Position leng
                 sc.SetState(SCE_VISUALPROLOG_STRING);
             } else if (sc.Match('"')) {
                 closingQuote = '"';
+                sc.SetState(SCE_VISUALPROLOG_STRING);
+            } else if (options.backQuotedStrings && sc.Match('`')) {
+                closingQuote = '`';
                 sc.SetState(SCE_VISUALPROLOG_STRING);
             } else if (sc.Match('#')) {
                 sc.SetState(SCE_VISUALPROLOG_KEY_DIRECTIVE);

--- a/test/examples/visualprolog/AllStyles.pl
+++ b/test/examples/visualprolog/AllStyles.pl
@@ -1,0 +1,57 @@
+% SCE_VISUALPROLOG_KEY_MAJOR (1)
+goal
+
+% SCE_VISUALPROLOG_KEY_MINOR (2)
+procedure
+
+% SCE_VISUALPROLOG_KEY_DIRECTIVE (3)
+#include
+
+% SCE_VISUALPROLOG_COMMENT_BLOCK (4)
+/**
+   SCE_VISUALPROLOG_COMMENT_KEY (6)
+   @detail
+   SCE_VISUALPROLOG_COMMENT_KEY_ERROR (7)
+   @unknown
+ /* SCE_VISUALPROLOG_IDENTIFIER (8)
+    SCE_VISUALPROLOG_VARIABLE (9)
+    SCE_VISUALPROLOG_ANONYMOUS (10)
+    SCE_VISUALPROLOG_NUMBER (11)
+    SCE_VISUALPROLOG_OPERATOR (12) */ */
+singleton -->
+    [S],
+    {
+        string_lower(S, L),
+        atom_codes(L, Bytes),
+        sort(0, @=<, Bytes, [95, _discard])
+    }.
+
+% SCE_VISUALPROLOG_COMMENT_LINE (5)
+% @detail
+% @unknown
+
+% SCE_VISUALPROLOG_STRING (16)
+"string"
+'string'
+% ISO Prolog back-quoted string
+`string`
+
+% SCE_VISUALPROLOG_STRING_ESCAPE (17)
+"\n"
+'\uAB12'
+
+% SCE_VISUALPROLOG_STRING_ESCAPE_ERROR (18)
+"\ "
+
+% SCE_VISUALPROLOG_STRING_EOL_OPEN (19)
+"open string
+
+% Not implemented for ISO/SWI-Prolog:
+% SCE_VISUALPROLOG_STRING_VERBATIM
+% SCE_VISUALPROLOG_STRING_VERBATIM_SPECIAL
+% SCE_VISUALPROLOG_STRING_VERBATIM_EOL
+@"verbatim string"
+@"""special"" verbatim string"
+@"multi-line
+  verbatim
+  string"

--- a/test/examples/visualprolog/AllStyles.pl.folded
+++ b/test/examples/visualprolog/AllStyles.pl.folded
@@ -1,0 +1,58 @@
+ 0 400 400   % SCE_VISUALPROLOG_KEY_MAJOR (1)
+ 0 400 400   goal
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_KEY_MINOR (2)
+ 0 400 400   procedure
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_KEY_DIRECTIVE (3)
+ 0 400 400   #include
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_COMMENT_BLOCK (4)
+ 0 400 400   /**
+ 0 400 400      SCE_VISUALPROLOG_COMMENT_KEY (6)
+ 0 400 400      @detail
+ 0 400 400      SCE_VISUALPROLOG_COMMENT_KEY_ERROR (7)
+ 0 400 400      @unknown
+ 0 400 400    /* SCE_VISUALPROLOG_IDENTIFIER (8)
+ 0 400 400       SCE_VISUALPROLOG_VARIABLE (9)
+ 0 400 400       SCE_VISUALPROLOG_ANONYMOUS (10)
+ 0 400 400       SCE_VISUALPROLOG_NUMBER (11)
+ 0 400 400       SCE_VISUALPROLOG_OPERATOR (12) */ */
+ 0 400 400   singleton -->
+ 0 400 400       [S],
+ 2 400 401 +     {
+ 0 401 401 |         string_lower(S, L),
+ 0 401 401 |         atom_codes(L, Bytes),
+ 0 401 401 |         sort(0, @=<, Bytes, [95, _discard])
+ 0 401 400 |     }.
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_COMMENT_LINE (5)
+ 0 400 400   % @detail
+ 0 400 400   % @unknown
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_STRING (16)
+ 0 400 400   "string"
+ 0 400 400   'string'
+ 0 400 400   % ISO Prolog back-quoted string
+ 0 400 400   `string`
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_STRING_ESCAPE (17)
+ 0 400 400   "\n"
+ 0 400 400   '\uAB12'
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_STRING_ESCAPE_ERROR (18)
+ 0 400 400   "\ "
+ 0 400 400   
+ 0 400 400   % SCE_VISUALPROLOG_STRING_EOL_OPEN (19)
+ 0 400 400   "open string
+ 0 400 400   
+ 0 400 400   % Not implemented for ISO/SWI-Prolog:
+ 0 400 400   % SCE_VISUALPROLOG_STRING_VERBATIM
+ 0 400 400   % SCE_VISUALPROLOG_STRING_VERBATIM_SPECIAL
+ 0 400 400   % SCE_VISUALPROLOG_STRING_VERBATIM_EOL
+ 0 400 400   @"verbatim string"
+ 0 400 400   @"""special"" verbatim string"
+ 0 400 400   @"multi-line
+ 0 400 400     verbatim
+ 0 400 400     string"
+ 1 400 400   

--- a/test/examples/visualprolog/AllStyles.pl.styled
+++ b/test/examples/visualprolog/AllStyles.pl.styled
@@ -1,0 +1,57 @@
+{5}% SCE_VISUALPROLOG_KEY_MAJOR (1){0}
+{1}goal{0}
+
+{5}% SCE_VISUALPROLOG_KEY_MINOR (2){0}
+{2}procedure{0}
+
+{5}% SCE_VISUALPROLOG_KEY_DIRECTIVE (3){0}
+{3}#include{0}
+
+{5}% SCE_VISUALPROLOG_COMMENT_BLOCK (4){0}
+{4}/**
+   SCE_VISUALPROLOG_COMMENT_KEY (6)
+   {6}@detail{4}
+   SCE_VISUALPROLOG_COMMENT_KEY_ERROR (7)
+   {7}@unknown{4}
+ /* SCE_VISUALPROLOG_IDENTIFIER (8)
+    SCE_VISUALPROLOG_VARIABLE (9)
+    SCE_VISUALPROLOG_ANONYMOUS (10)
+    SCE_VISUALPROLOG_NUMBER (11)
+    SCE_VISUALPROLOG_OPERATOR (12) */ */{0}
+{8}singleton{0} {12}-->{0}
+    {12}[{9}S{12}],{0}
+    {12}{{0}
+        {1}string_lower{12}({9}S{12},{0} {9}L{12}),{0}
+        {1}atom_codes{12}({9}L{12},{0} {9}Bytes{12}),{0}
+        {1}sort{12}({11}0{12},{0} {12}@=<,{0} {9}Bytes{12},{0} {12}[{11}95{12},{0} {10}_discard{12}]){0}
+    {12}}.{0}
+
+{5}% SCE_VISUALPROLOG_COMMENT_LINE (5){0}
+{5}% {6}@detail{0}
+{5}% {7}@unknown{0}
+
+{5}% SCE_VISUALPROLOG_STRING (16){0}
+{16}"string"{0}
+{16}'string'{0}
+{5}% ISO Prolog back-quoted string{0}
+{16}`string`{0}
+
+{5}% SCE_VISUALPROLOG_STRING_ESCAPE (17){0}
+{16}"{17}\n{16}"{0}
+{16}'{17}\uAB12{16}'{0}
+
+{5}% SCE_VISUALPROLOG_STRING_ESCAPE_ERROR (18){0}
+{16}"{18}\ {16}"{0}
+
+{5}% SCE_VISUALPROLOG_STRING_EOL_OPEN (19){0}
+{16}"open string{19}
+{0}
+{5}% Not implemented for ISO/SWI-Prolog:{0}
+{5}% SCE_VISUALPROLOG_STRING_VERBATIM{0}
+{5}% SCE_VISUALPROLOG_STRING_VERBATIM_SPECIAL{0}
+{5}% SCE_VISUALPROLOG_STRING_VERBATIM_EOL{0}
+{12}@{16}"verbatim string"{0}
+{12}@{16}"""special"" verbatim string"{0}
+{12}@{16}"multi-line{19}
+{0}  {8}verbatim{0}
+  {8}string{16}"{19}

--- a/test/examples/visualprolog/SciTE.properties
+++ b/test/examples/visualprolog/SciTE.properties
@@ -1,19 +1,29 @@
-lexer.*.pro=visualprolog
+lexer.*.pro;*.pl=visualprolog
 fold=1
 
+# Visual Prolog properties
+match AllStyles.pro
+  lexer.visualprolog.verbatim.strings=1
+  lexer.visualprolog.backquoted.strings=0
+
+# ISO/SWI-Prolog properties
+match AllStyles.pl
+  lexer.visualprolog.verbatim.strings=0
+  lexer.visualprolog.backquoted.strings=1
+
 # major keywords
-keywords.*.pro=goal namespace interface class implement open inherits supports resolve delegate \
-monitor constants domains predicates constructors properties clauses facts
+keywords.*.pro;*.pl=goal namespace interface class implement open inherits supports resolve delegate \
+monitor constants domains predicates constructors properties clauses facts string_lower atom_codes sort
 
 # minor keywords
-keywords2.*.pro=any binary binaryNonAtomic boolean char compareResult factDB guard handle integer64 \
+keywords2.*.pro;*.pl=any binary binaryNonAtomic boolean char compareResult factDB guard handle integer64 \
 integerNative language null pointer real real32 stdcall string8 symbol apicall c thiscall prolog \
 digits if then elseif else endif foreach do try catch finally erroneous failure procedure determ multi \
 nondeterm anyflow and or externally from div mod rem quot in orelse otherwise unsigned unsigned64 \
 unsignedNative
 
 # directives
-keywords3.*.pro=include bininclude requires orrequires error message export externally options
+keywords3.*.pro;*.pl=include bininclude requires orrequires error message export externally options
 
 # documentation keywords
-keywords4.*.pro=short detail end exception withdomain
+keywords4.*.pro;*.pl=short detail end exception withdomain


### PR DESCRIPTION
This PR adds two patches to support also other prolog dialects like SWI with the VisualProlog lexer:

- allows disabling verbatim strings introduced by `@` which aren't used by SWI (instead `@` is used to pass operators as arguments and `@` is treated as part of the operator)
- allows enabling backquted strings such as `` `string` ``
- plus unit tests

Many thanks to @rdipardo for providing many parts of the code.

For more details, see https://github.com/geany/geany/pull/3171.