### PR TITLE
LexPowershell: End simple string at close quote or eol

### DIFF
--- a/lexers/LexPowerShell.cxx
+++ b/lexers/LexPowerShell.cxx
@@ -50,7 +50,7 @@ static void ColourisePowerShellDoc(Sci_PositionU startPos, Sci_Position length, 
 	for (; sc.More(); sc.Forward()) {
 
 		if (sc.state == SCE_POWERSHELL_COMMENT) {
-			if (sc.atLineEnd) {
+			if (sc.ch == '\r' || sc.atLineEnd) {
 				sc.SetState(SCE_POWERSHELL_DEFAULT);
 			}
 		} else if (sc.state == SCE_POWERSHELL_COMMENTSTREAM) {
@@ -76,14 +76,14 @@ static void ColourisePowerShellDoc(Sci_PositionU startPos, Sci_Position length, 
 			}
 		} else if (sc.state == SCE_POWERSHELL_STRING) {
 			// This is a doubles quotes string
-			if (sc.ch == '\"') {
+			if (sc.ch == '\"' || sc.atLineEnd) {
 				sc.ForwardSetState(SCE_POWERSHELL_DEFAULT);
 			} else if (sc.ch == '`') {
 				sc.Forward(); // skip next escaped character
 			}
 		} else if (sc.state == SCE_POWERSHELL_CHARACTER) {
 			// This is a single quote string
-			if (sc.ch == '\'') {
+			if (sc.ch == '\'' || sc.atLineEnd) {
 				sc.ForwardSetState(SCE_POWERSHELL_DEFAULT);
 			}
 		} else if (sc.state == SCE_POWERSHELL_HERE_STRING) {

--- a/test/examples/powershell/Pull99.ps1
+++ b/test/examples/powershell/Pull99.ps1
@@ -1,0 +1,21 @@
+# End simple string at closing quote or EOL.
+
+$variable = 'test'
+function test
+{
+}
+
+$variable = 'test
+function test
+{
+}
+
+$variable = "test"
+function test
+{
+}
+
+$variable = "test
+function test
+{
+}

--- a/test/examples/powershell/Pull99.ps1.folded
+++ b/test/examples/powershell/Pull99.ps1.folded
@@ -1,0 +1,22 @@
+ 0 400 400   # End simple string at closing quote or EOL.
+ 1 400 400   
+ 0 400 400   $variable = 'test'
+ 0 400 400   function test
+ 2 400 401 + {
+ 0 401 400 | }
+ 1 400 400   
+ 0 400 400   $variable = 'test
+ 0 400 400   function test
+ 2 400 401 + {
+ 0 401 400 | }
+ 1 400 400   
+ 0 400 400   $variable = "test"
+ 0 400 400   function test
+ 2 400 401 + {
+ 0 401 400 | }
+ 1 400 400   
+ 0 400 400   $variable = "test
+ 0 400 400   function test
+ 2 400 401 + {
+ 0 401 400 | }
+ 0 400   0   

--- a/test/examples/powershell/Pull99.ps1.styled
+++ b/test/examples/powershell/Pull99.ps1.styled
@@ -1,0 +1,21 @@
+{1}# End simple string at closing quote or EOL.{0}
+
+{5}$variable{0} {6}={0} {3}'test'{0}
+{7}function{0} {7}test{0}
+{6}{{0}
+{6}}{0}
+
+{5}$variable{0} {6}={0} {3}'test
+{7}function{0} {7}test{0}
+{6}{{0}
+{6}}{0}
+
+{5}$variable{0} {6}={0} {2}"test"{0}
+{7}function{0} {7}test{0}
+{6}{{0}
+{6}}{0}
+
+{5}$variable{0} {6}={0} {2}"test
+{7}function{0} {7}test{0}
+{6}{{0}
+{6}}{0}


### PR DESCRIPTION
An issue has been raised at the NotePad++ repo: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12121

An unterminated simple string, single quotes or double quotes, causes the string style to continue down the document.

This causes any later styling and folding to fail while editing an unterminated string.

Currently, a simple string is terminated by a closing quote. The fix is to also terminate at the EOL.

This is a before and after:

![bug_powershell_strings](https://user-images.githubusercontent.com/58158242/189332997-dd2a6136-147a-4823-a0c8-b6babb2c54c7.gif)

Another minor issue is the comment line style includes the CR character so a check for `\r` has been added.

Testfiles are included.