### PR TITLE
Don't highlight match and case as keywords in contexts where they probably aren't used as keywords

### DIFF
--- a/lexers/LexPython.cxx
+++ b/lexers/LexPython.cxx
@@ -218,6 +218,56 @@ bool IsFirstNonWhitespace(Sci_Position pos, Accessor &styler) {
 	return true;
 }
 
+unsigned char GetNextNonWhitespaceChar(Accessor& styler, Sci_PositionU pos, Sci_PositionU maxPos, Sci_PositionU* charPosPtr = nullptr)
+{
+    while (pos < maxPos) {
+        unsigned char ch = styler.SafeGetCharAt(pos, '\0');
+        if (!(ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')) {
+            if (charPosPtr != nullptr) {
+                *charPosPtr = pos;
+            }
+            return ch;
+        }
+        pos++;
+    }
+
+    return '\0';
+}
+
+// Returns whether symbol is "match" or "case" and it is an identifier &
+// not a keyword. Does not require the line to end with : so "match\n"
+// and "match (x)\n" return false because match could be a keyword once
+// more text is added
+bool IsMatchOrCaseIdentifier(StyleContext& sc, Accessor& styler, const char* symbol)
+{
+    if (strcmp(symbol, "match") != 0 && strcmp(symbol, "case") != 0) {
+        return false;
+    }
+
+    if (!IsFirstNonWhitespace(sc.currentPos - strlen(symbol), styler)) {
+        return true;
+    }
+
+    // The match keyword can be followed by an expression; the case keyword
+    // is a bit more restrictive but not much. Here, we look for the next
+    // char and return false if the char cannot start an expression; for '.'
+    // we look at the following char to see if it's a digit because .1 is a
+    // number
+    Sci_PositionU nextCharPos = 0;
+    unsigned char nextChar = GetNextNonWhitespaceChar(styler, sc.currentPos, sc.lineEnd, &nextCharPos);
+    if (nextChar == '=' || nextChar == '#') {
+        return true;
+    }
+    if (nextChar == '.' && nextCharPos >= sc.currentPos) {
+        unsigned char followingChar = GetNextNonWhitespaceChar(styler, nextCharPos+1, sc.lineEnd);
+        if (!isdigit(followingChar)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Options used for LexerPython
 struct OptionsPython {
 	int whingeLevel;
@@ -613,7 +663,7 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 				int style = SCE_P_IDENTIFIER;
 				if ((kwLast == kwImport) && (strcmp(s, "as") == 0)) {
 					style = SCE_P_WORD;
-				} else if (keywords.InList(s)) {
+				} else if (keywords.InList(s) && !IsMatchOrCaseIdentifier(sc, styler, s)) {
 					style = SCE_P_WORD;
 				} else if (kwLast == kwClass) {
 					style = SCE_P_CLASSNAME;

--- a/test/examples/python/SciTE.properties
+++ b/test/examples/python/SciTE.properties
@@ -1,5 +1,5 @@
 lexer.*.py=python
-keywords.*.py=class def else for if import in pass print return while with yield
+keywords.*.py=class def else for if import in pass print return while with yield match case
 keywords2.*.py=hilight
 fold=1
 fold.compact=1

--- a/test/examples/python/matchcase.py
+++ b/test/examples/python/matchcase.py
@@ -1,0 +1,25 @@
+# Match and case as keywords
+match (x):
+    case +1:
+        pass
+    case -1:
+        pass
+    case []:
+        pass
+    
+# Match and case as identifiers
+match = 1
+def match():
+    pass
+match.group()
+1 + match
+case.attribute
+
+# Unfortunately wrong classifications; should be rare in real code because
+# non-call expressions usually don't begin lines, the exceptions are match(x)
+# and case(x)
+match(x)
+case(x)
+match + 1
+case + 1
+case[1]

--- a/test/examples/python/matchcase.py.folded
+++ b/test/examples/python/matchcase.py.folded
@@ -1,0 +1,26 @@
+ 0 400   0   # Match and case as keywords
+ 2 400   0 + match (x):
+ 2 404   0 +     case +1:
+ 0 408   0 |         pass
+ 2 404   0 +     case -1:
+ 0 408   0 |         pass
+ 2 404   0 +     case []:
+ 0 408   0 |         pass
+ 1 408   0 |     
+ 0 400   0   # Match and case as identifiers
+ 0 400   0   match = 1
+ 2 400   0 + def match():
+ 0 404   0 |     pass
+ 0 400   0   match.group()
+ 0 400   0   1 + match
+ 0 400   0   case.attribute
+ 1 400   0   
+ 0 400   0   # Unfortunately wrong classifications; should be rare in real code because
+ 0 400   0   # non-call expressions usually don't begin lines, the exceptions are match(x)
+ 0 400   0   # and case(x)
+ 0 400   0   match(x)
+ 0 400   0   case(x)
+ 0 400   0   match + 1
+ 0 400   0   case + 1
+ 0 400   0   case[1]
+ 1 400   0   

--- a/test/examples/python/matchcase.py.styled
+++ b/test/examples/python/matchcase.py.styled
@@ -1,0 +1,25 @@
+{1}# Match and case as keywords{0}
+{5}match{0} {10}({11}x{10}):{0}
+    {5}case{0} {10}+{2}1{10}:{0}
+        {5}pass{0}
+    {5}case{0} {10}-{2}1{10}:{0}
+        {5}pass{0}
+    {5}case{0} {10}[]:{0}
+        {5}pass{0}
+    
+{1}# Match and case as identifiers{0}
+{11}match{0} {10}={0} {2}1{0}
+{5}def{0} {9}match{10}():{0}
+    {5}pass{0}
+{11}match{10}.{11}group{10}(){0}
+{2}1{0} {10}+{0} {11}match{0}
+{11}case{10}.{11}attribute{0}
+
+{1}# Unfortunately wrong classifications; should be rare in real code because{0}
+{1}# non-call expressions usually don't begin lines, the exceptions are match(x){0}
+{1}# and case(x){0}
+{5}match{10}({11}x{10}){0}
+{5}case{10}({11}x{10}){0}
+{5}match{0} {10}+{0} {2}1{0}
+{5}case{0} {10}+{0} {2}1{0}
+{5}case{10}[{2}1{10}]{0}


### PR DESCRIPTION
Changes the python lever to classify match and case as keywords if they are in the keywords set and are in a position where they are probably keywords and not identifiers -- at the start of the line and not followed by a '=' or '.'. 

There are ambiguous cases where match / case could be a keyword or identifier that are classified as a keyword. This could be resolved by scanning ahead for a terminating ':', but it would require something close to a python tokenizer and the match / case should probably be classified as keywords while the line is being entered. An example are the lines 'match (x)' and 'match (x):' -- match is an identifier in the first, but a keyword in the second.

There are cases where the statement starts on the prior line that aren't handled correctly, but should be rare and would be difficult to fix within the current approach.

I opted not to add an option to control this, but could if someone wants to highlight all match and case symbols as keywords.

Note that match and case were added to python/SciTE.properties for the tests; this doesn't seem to affect the other tests.