### PR TITLE
Do not build C++ stl modules

### DIFF
--- a/src/Lexilla.vcxproj
+++ b/src/Lexilla.vcxproj
@@ -79,6 +79,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Starting with Visual Studio 2022 17.6 Preview 3, C++ stl modules (std.ixx, std.compat.ixx) are built by default.
This change disables the building of those modules, as there is no use for them and it takes a significant amount of time to build them.