### PR TITLE
Use proper C prototypes in header used from C

### DIFF
--- a/include/Lexilla.h
+++ b/include/Lexilla.h
@@ -48,20 +48,20 @@ using Scintilla::ILexer5;
 typedef void ILexer5;
 #endif
 
-typedef ILexer5 *(*LexerFactoryFunction)();
+typedef ILexer5 *(*LexerFactoryFunction)(void);
 
 #if defined(__cplusplus)
 namespace Lexilla {
 #endif
 
-typedef int (LEXILLA_CALL *GetLexerCountFn)();
+typedef int (LEXILLA_CALL *GetLexerCountFn)(void);
 typedef void (LEXILLA_CALL *GetLexerNameFn)(unsigned int Index, char *name, int buflength);
 typedef LexerFactoryFunction(LEXILLA_CALL *GetLexerFactoryFn)(unsigned int Index);
 typedef ILexer5*(LEXILLA_CALL *CreateLexerFn)(const char *name);
 DEPRECATE_DEFINITION typedef const char *(LEXILLA_CALL *LexerNameFromIDFn)(int identifier);
-typedef const char *(LEXILLA_CALL *GetLibraryPropertyNamesFn)();
+typedef const char *(LEXILLA_CALL *GetLibraryPropertyNamesFn)(void);
 typedef void(LEXILLA_CALL *SetLibraryPropertyFn)(const char *key, const char *value);
-typedef const char *(LEXILLA_CALL *GetNameSpaceFn)();
+typedef const char *(LEXILLA_CALL *GetNameSpaceFn)(void);
 
 #if defined(__cplusplus)
 }
@@ -85,13 +85,13 @@ extern "C" {
 #endif
 
 ILexer5 * LEXILLA_CALL CreateLexer(const char *name);
-int LEXILLA_CALL GetLexerCount();
+int LEXILLA_CALL GetLexerCount(void);
 void LEXILLA_CALL GetLexerName(unsigned int index, char *name, int buflength);
 LexerFactoryFunction LEXILLA_CALL GetLexerFactory(unsigned int index);
 DEPRECATE_DEFINITION const char *LEXILLA_CALL LexerNameFromID(int identifier);
-const char * LEXILLA_CALL GetLibraryPropertyNames();
+const char * LEXILLA_CALL GetLibraryPropertyNames(void);
 void LEXILLA_CALL SetLibraryProperty(const char *key, const char *value);
-const char *LEXILLA_CALL GetNameSpace();
+const char *LEXILLA_CALL GetNameSpace(void);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Lexilla.h is expected to be usable from C code, so use proper C prototypes for a C compiler to be happy: in C, an empty argument list is written as `(void)`, `()` alone denotes an *unspecified* argument list.

GCC and clang emits a warning with `-Wstrict-prototypes` in C mode.