### PR TITLE
Fixed python decorators

### DIFF
--- a/lexers/LexPython.cxx
+++ b/lexers/LexPython.cxx
@@ -761,7 +761,7 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 				sc.SetState(SCE_P_DEFAULT);
 			}
 		} else if (sc.state == SCE_P_DECORATOR) {
-			if (!IsAWordStart(sc.ch, options.unicodeIdentifiers)) {
+			if (!IsAWordChar(sc.ch, options.unicodeIdentifiers)) {
 				sc.SetState(SCE_P_DEFAULT);
 			}
 		} else if (IsPySingleQuoteStringState(sc.state)) {


### PR DESCRIPTION
See: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5894
See: https://sourceforge.net/p/scintilla/bugs/2139/

Notepad++ now colors decorators correctly:
Before:
![01](https://github.com/ScintillaOrg/lexilla/assets/7983249/7ce7c657-deef-494b-8197-63b943a5c6c9)

Fixed:
![02](https://github.com/ScintillaOrg/lexilla/assets/7983249/7e2d5fdd-f997-4590-ba74-4dbeba13cc24)

I took the fix code from here (@Ekopalypse wrote it):
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5894#issuecomment-508936642