### PR TITLE
Fix lexing of rb'' and rf'' python strings

### DIFF
--- a/test/examples/python/strings.py
+++ b/test/examples/python/strings.py
@@ -1,0 +1,16 @@
+# Simple raw string
+r''
+
+# Raw f-string
+rf''
+fr''
+
+# Raw byte string
+rb''
+br''
+
+# Raw unicode strings: ur'' is valid in 2.7 (but not in 3) -- always lexed as
+# valid; ru'' is never valid
+ru''
+ur''
+

--- a/test/examples/python/strings.py.folded
+++ b/test/examples/python/strings.py.folded
@@ -1,0 +1,17 @@
+ 0 400   0   # Simple raw string
+ 0 400   0   r''
+ 1 400   0   
+ 0 400   0   # Raw f-string
+ 0 400   0   rf''
+ 0 400   0   fr''
+ 1 400   0   
+ 0 400   0   # Raw byte string
+ 0 400   0   rb''
+ 0 400   0   br''
+ 1 400   0   
+ 0 400   0   # Raw unicode strings: ur'' is valid in 2.7 (but not in 3) -- always lexed as
+ 0 400   0   # valid; ru'' is never valid
+ 0 400   0   ru''
+ 0 400   0   ur''
+ 1 400   0   
+ 1 400   0   

--- a/test/examples/python/strings.py.styled
+++ b/test/examples/python/strings.py.styled
@@ -1,0 +1,16 @@
+{1}# Simple raw string{0}
+{4}r''{0}
+
+{1}# Raw f-string{0}
+{17}rf''{0}
+{17}fr''{0}
+
+{1}# Raw byte string{0}
+{4}rb''{0}
+{4}br''{0}
+
+{1}# Raw unicode strings: ur'' is valid in 2.7 (but not in 3) -- always lexed as{0}
+{1}# valid; ru'' is never valid{0}
+{11}ru{4}''{0}
+{4}ur''{0}
+


### PR DESCRIPTION
This lexes all of rb'', br'', rf'', fr'', and ur'' as strings but not ru''. 

Interestingly ur'' is valid in python 2.7 but not in python 3. I kept things simple and did not add an option for this so ur'' is accepted whenever u'' is. 