### PR TITLE
A decimal separator is not required for scaled decimal numbers, nor n…

### DIFF
--- a/lexers/LexSmalltalk.cxx
+++ b/lexers/LexSmalltalk.cxx
@@ -327,4 +327,4 @@ static const char* const smalltalkWordListDesc[] = {
     0
 };
 
-LexerModule lmSmalltalk(SCLEX_SMALLTALK, colorizeSmalltalkDoc, "smalltalk", NULL, smalltalkWordListDesc);
+extern const LexerModule lmSmalltalk(SCLEX_SMALLTALK, colorizeSmalltalkDoc, "smalltalk", NULL, smalltalkWordListDesc);

--- a/lexers/LexSmalltalk.cxx
+++ b/lexers/LexSmalltalk.cxx
@@ -191,10 +191,13 @@ static void handleNumeric(StyleContext& sc)
     }
     else
         radix = 10;
-    if (sc.chNext != '.' || !isDigitOfRadix(sc.GetRelative(2), radix))
-        return;
-    sc.Forward();
-    skipInt(sc, radix);
+    if (sc.chNext == '.') {
+		if (!isDigitOfRadix(sc.GetRelative(2), radix))
+			return;
+		sc.Forward();
+		skipInt(sc, radix);
+	}
+    
     if (sc.chNext == 's') {
         // ScaledDecimal
         sc.Forward();


### PR DESCRIPTION
In Smalltalk, a decimal separator is not required for scaled decimal numbers, nor numbers specifying an exponent.

Fix to style 32s2 and 4e3 equivalently to 32.0s2 and 4.0e3, instead of parsing s2/e3 as separate selectors