### PR TITLE
TOML: Don't treat keys without values as errors

### DIFF
--- a/lexers/LexTOML.cxx
+++ b/lexers/LexTOML.cxx
@@ -259,12 +259,9 @@ void ColouriseTOMLDoc(Sci_PositionU startPos, Sci_Position lengthDoc, int initSt
 						}
 					} else if (sc.state == SCE_TOML_KEY && !IsTOMLUnquotedKey(sc.ch)) {
 						const int chNext = GetLineNextChar(sc);
-						if (chNext == '=') {
+						if (chNext == '=' || (chNext != '.' && chPrevNonWhite != '.')) {
 							keyState = TOMLKeyState::End;
 							sc.SetState(SCE_TOML_DEFAULT);
-						} else if (chNext != '.' && chPrevNonWhite != '.') {
-							sc.ChangeState(SCE_TOML_ERROR);
-							continue;
 						}
 					}
 				}

--- a/test/examples/toml/AllStyles.toml
+++ b/test/examples/toml/AllStyles.toml
@@ -186,5 +186,6 @@ points = [ { x = 1, y = 2, z = 3 },
            { x = 7, y = 8, z = 9 },
            { x = 2, y = 4, z = 8 } ]
 
+~~~~ = true       # invalid character in key
 invalid           # invalid, missing value
 key = identifier  # also invalid, identifier must be one of true, false, inf, nan

--- a/test/examples/toml/AllStyles.toml.folded
+++ b/test/examples/toml/AllStyles.toml.folded
@@ -186,6 +186,7 @@
  0 401   0 |            { x = 7, y = 8, z = 9 },
  0 401   0 |            { x = 2, y = 4, z = 8 } ]
  0 401   0 | 
+ 0 401   0 | ~~~~ = true       # invalid character in key
  0 401   0 | invalid           # invalid, missing value
  0 401   0 | key = identifier  # also invalid, identifier must be one of true, false, inf, nan
  0 401   0 | 

--- a/test/examples/toml/AllStyles.toml.styled
+++ b/test/examples/toml/AllStyles.toml.styled
@@ -186,5 +186,6 @@ trimmed in raw strings.
            {8}{{0} {6}x{0} {8}={0} {4}7{8},{0} {6}y{0} {8}={0} {4}8{8},{0} {6}z{0} {8}={0} {4}9{0} {8}},{0}
            {8}{{0} {6}x{0} {8}={0} {4}2{8},{0} {6}y{0} {8}={0} {4}4{8},{0} {6}z{0} {8}={0} {4}8{0} {8}}{0} {8}]{0}
 
-{7}invalid           {1}# invalid, missing value
+{7}~~~~ = true       {1}# invalid character in key
+{6}invalid{0}           {1}# invalid, missing value
 {6}key{0} {8}={0} {2}identifier{0}  {1}# also invalid, identifier must be one of true, false, inf, nan


### PR DESCRIPTION
While keys without = are not allowed in TOML, this situation happens all the time while editing a TOML file (until one types = after key) which produces annoying error-colorization and then re-colorization after = is inserted.

Better to allow this at the lexer level and leave the error detection job to various linters.