### PR TITLE
LexErrorlist fixes

### DIFF
--- a/lexers/LexErrorList.cxx
+++ b/lexers/LexErrorList.cxx
@@ -93,9 +93,12 @@ int RecogniseErrorListLine(const char *lineBuffer, Sci_PositionU lengthLine, Sci
 		} else {
 			return SCE_ERR_DIFF_ADDITION;
 		}
-	} else if (lineBuffer[0] == '-') {
+	} else if (lineBuffer[0] == '-' && !strstart(lineBuffer, "-r")) {
 		if (strstart(lineBuffer, "--- ")) {
 			return SCE_ERR_DIFF_MESSAGE;
+		} else if (strstart(lineBuffer, "-- ")) {
+			// CMake status messages
+			return SCE_ERR_DEFAULT;
 		} else {
 			return SCE_ERR_DIFF_DELETION;
 		}


### PR DESCRIPTION
- Better handling for CMake status messages
- Do not consider 'ls -l' output as "Diff deleted messages"


Two screenshots showing the problems I am fixing with this PR:

1. CMake status messages are styled as "DIFF_DELETE"
2. `ls -la` output lines starting with `-r` are styled as "DIFF_DELETE"

<img width="871" alt="cmake-status-bad" src="https://github.com/user-attachments/assets/9ca2f2ae-0a3e-49eb-af70-c087d2420285">
<img width="547" alt="ls-l-bad" src="https://github.com/user-attachments/assets/e6b037c5-e798-4773-b2ae-f99caa43c361">

After the fix:

<img width="580" alt="cmake-status-good" src="https://github.com/user-attachments/assets/6e2977c7-232b-4d28-a377-09d4d315f867">
<img width="482" alt="ls-l-good" src="https://github.com/user-attachments/assets/18d70e53-5b08-465b-a1ba-1b637cfda4ef">
