### PR TITLE
LexPython: Improve detecting of attributes and decorators

### DIFF
--- a/lexers/LexPython.cxx
+++ b/lexers/LexPython.cxx
@@ -714,9 +714,10 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 							pos--;
 							ch = styler.SafeGetCharAt(pos, '\0');
 						}
-						if (pos < 0 || ch == '.') {
+						if (ch == '.') {
 							// Is this an attribute we could style? if it is, do as asked
-							bool isComment = false;
+							styler.Flush(); // need to be able to check to see if '.' is a comment or not, and need to flush the styler to check
+							bool isComment = (styler.StyleIndexAt(pos) == SCE_P_COMMENTLINE) || (styler.StyleIndexAt(pos) == SCE_P_COMMENTBLOCK);
 							bool isDecoratorAttribute = false;
 							const Sci_Position attrLine = styler.GetLine(pos);
 							for (Sci_Position i = styler.LineStart(attrLine); i < pos; i++) {
@@ -726,7 +727,7 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 								if (attrCh == '#')
 									isComment = true;
 								// Detect if this attribute belongs to a decorator
-								if (!IsASpaceOrTab(ch))
+								if (!IsASpaceOrTab(attrCh))
 									break;
 							}
 							if (((isDecoratorAttribute) && (!isComment)) && (((options.decoratorAttributes == 1)  && (style == SCE_P_IDENTIFIER)) || (options.decoratorAttributes == 2))) {

--- a/lexers/LexPython.cxx
+++ b/lexers/LexPython.cxx
@@ -716,7 +716,7 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 						}
 						if (ch == '.') {
 							// Is this an attribute we could style? if it is, do as asked
-							bool isComment = (styler.BufferStyleAt(pos) == SCE_P_COMMENTLINE) || (styler.BufferStyleAt(pos) == SCE_P_COMMENTBLOCK);
+							bool isComment = AnyOf(styler.BufferStyleAt(pos), SCE_P_COMMENTLINE, SCE_P_COMMENTBLOCK);
 							bool isDecoratorAttribute = false;
 							const Sci_Position attrLine = styler.GetLine(pos);
 							for (Sci_Position i = styler.LineStart(attrLine); i < pos; i++) {

--- a/lexers/LexPython.cxx
+++ b/lexers/LexPython.cxx
@@ -716,8 +716,7 @@ void SCI_METHOD LexerPython::Lex(Sci_PositionU startPos, Sci_Position length, in
 						}
 						if (ch == '.') {
 							// Is this an attribute we could style? if it is, do as asked
-							styler.Flush(); // need to be able to check to see if '.' is a comment or not, and need to flush the styler to check
-							bool isComment = (styler.StyleIndexAt(pos) == SCE_P_COMMENTLINE) || (styler.StyleIndexAt(pos) == SCE_P_COMMENTBLOCK);
+							bool isComment = (styler.BufferStyleAt(pos) == SCE_P_COMMENTLINE) || (styler.BufferStyleAt(pos) == SCE_P_COMMENTBLOCK);
 							bool isDecoratorAttribute = false;
 							const Sci_Position attrLine = styler.GetLine(pos);
 							for (Sci_Position i = styler.LineStart(attrLine); i < pos; i++) {

--- a/test/examples/python/attributes/attrib-decorator.py
+++ b/test/examples/python/attributes/attrib-decorator.py
@@ -1,0 +1,9 @@
+# issue#294 also pointed out that decorator attributes behaved differently
+#   for left-justified decorators vs indented decorators
+
+@decorator.attribute
+def foo():
+    @decorator.attribute
+    def bar():
+        pass
+    bar()

--- a/test/examples/python/attributes/attrib-decorator.py.folded
+++ b/test/examples/python/attributes/attrib-decorator.py.folded
@@ -1,0 +1,10 @@
+ 0 400   0   # issue#294 also pointed out that decorator attributes behaved differently
+ 0 400   0   #   for left-justified decorators vs indented decorators
+ 1 400   0   
+ 0 400   0   @decorator.attribute
+ 2 400   0 + def foo():
+ 0 404   0 |     @decorator.attribute
+ 2 404   0 +     def bar():
+ 0 408   0 |         pass
+ 0 404   0 |     bar()
+ 1 404   0 | 

--- a/test/examples/python/attributes/attrib-decorator.py.styled
+++ b/test/examples/python/attributes/attrib-decorator.py.styled
@@ -1,0 +1,9 @@
+{1}# issue#294 also pointed out that decorator attributes behaved differently{0}
+{1}#   for left-justified decorators vs indented decorators{0}
+
+{15}@decorator{10}.{15}attribute{0}
+{5}def{0} {9}foo{10}():{0}
+    {15}@decorator{10}.{15}attribute{0}
+    {5}def{0} {9}bar{10}():{0}
+        {5}pass{0}
+    {11}bar{10}(){0}

--- a/test/examples/python/attributes/attrib-id.py
+++ b/test/examples/python/attributes/attrib-id.py
@@ -1,0 +1,18 @@
+varname = 1
+# identifier in first line was mis-styled as attribute when bug existed
+
+# left comment ends with period.  this was okay before bug.
+varname = 2
+
+x = 1 # comment after code ends with period. this failed when bug existed.
+varname = 3
+
+def dummy():
+    # indented comment ends with period.this failed when bug existed.
+    varname = 4
+
+x = 2 ## comment block is the same.
+varname = 5
+
+# per issue#294, identifiers were mis-styled as attributes when at beginning of file
+# and when after a non-left-justifed comment

--- a/test/examples/python/attributes/attrib-id.py.folded
+++ b/test/examples/python/attributes/attrib-id.py.folded
@@ -1,0 +1,18 @@
+ 0 400   0   varname = 1
+ 0 400   0   # identifier in first line was mis-styled as attribute when bug existed
+ 1 400   0   
+ 0 400   0   # left comment ends with period.  this was okay before bug.
+ 0 400   0   varname = 2
+ 1 400   0   
+ 0 400   0   x = 1 # comment after code ends with period. this failed when bug existed.
+ 0 400   0   varname = 3
+ 1 400   0   
+ 2 400   0 + def dummy():
+ 0 404   0 |     # indented comment ends with period.this failed when bug existed.
+ 0 404   0 |     varname = 4
+ 1 400   0   
+ 0 400   0   x = 2 ## comment block is the same.
+ 0 400   0   varname = 5
+ 1 400   0   
+ 0 400   0   # per issue#294, identifiers were mis-styled as attributes when at beginning of file
+ 0 400   0   # and when after a non-left-justifed comment

--- a/test/examples/python/attributes/attrib-id.py.styled
+++ b/test/examples/python/attributes/attrib-id.py.styled
@@ -1,0 +1,18 @@
+{11}varname{0} {10}={0} {2}1{0}
+{1}# identifier in first line was mis-styled as attribute when bug existed{0}
+
+{1}# left comment ends with period.  this was okay before bug.{0}
+{11}varname{0} {10}={0} {2}2{0}
+
+{11}x{0} {10}={0} {2}1{0} {1}# comment after code ends with period. this failed when bug existed.{0}
+{11}varname{0} {10}={0} {2}3{0}
+
+{5}def{0} {9}dummy{10}():{0}
+    {1}# indented comment ends with period.this failed when bug existed.{0}
+    {11}varname{0} {10}={0} {2}4{0}
+
+{11}x{0} {10}={0} {2}2{0} {12}## comment block is the same.{0}
+{11}varname{0} {10}={0} {2}5{0}
+
+{1}# per issue#294, identifiers were mis-styled as attributes when at beginning of file{0}
+{1}# and when after a non-left-justifed comment


### PR DESCRIPTION
1. Fix bug of identifier at start of file mis-styled as attribute by not checking for `pos<0`
2. Fix bug where period at end of comment can misidentify the next line as an attribute
3. Fix bug in not recognizing `@decorator` or `@decorator.attribute` when decorator is indented by checking `if(!IsASpaceOrTab(attrCh))`
4. Add test cases for this group of bugs

fixes #294