### PR TITLE
Raku: fix compiler warning

### DIFF
--- a/lexers/LexRaku.cxx
+++ b/lexers/LexRaku.cxx
@@ -1424,7 +1424,7 @@ void SCI_METHOD LexerRaku::Lex(Sci_PositionU startPos, Sci_Position length, int 
 				}
 				const int state = sc.state;
 				sc.Forward();
-				char ch_delim = 0;
+				int ch_delim = 0;
 				if (setSpecialVar.Contains(sc.ch)
 						&& !setWord.Contains(sc.chNext)) {	// Process Special Var
 					ch_delim = -1;


### PR DESCRIPTION
g++ generates the following warning
```
../lexers/LexRaku.cxx: In member function ‘virtual void LexerRaku::Lex(Sci_PositionU, Sci_Position, int, Scintilla::IDocument*)’: ../lexers/LexRaku.cxx:1440:46: warning: comparison is always true due to limited range of data type [-Wtype-limits]
 1440 |                                 if (ch_delim >= 0) {
      |                                     ~~~~~~~~~^~~~
```
probably because `char` can be unsigned by default on some platforms. The patch replaces it with `int` but could probably also be just `signed char`.