### PR TITLE
LexErrorList: allow "bright" ANSI sequencse (ESC[90m - ESC[97m)

### DIFF
--- a/lexers/LexErrorList.cxx
+++ b/lexers/LexErrorList.cxx
@@ -336,6 +336,10 @@ int StyleFromSequence(const char *seq) noexcept {
 			else if (base >= 30 && base <= 37) {
 				colour = base - 30;
 			}
+			else if (base >= 90 && base <= 97) {
+				colour = base - 90;
+				bold = 1;
+			}
 		}
 		seq++;
 	}

--- a/test/examples/errorlist/BoldOrBright.err
+++ b/test/examples/errorlist/BoldOrBright.err
@@ -1,0 +1,17 @@
+Escape Sequence 32m
+[32mColour 32 (Green)[0m
+
+Escape Sequence 1;32m
+[1;32mColour 32 (Green) + Bold[0m
+
+Escape Sequence 92m
+[92mColour 92 (Bright Green)[0m
+
+Escape Sequence 36m
+[36mColour 36 (Cyan)[0m
+
+Escape Sequence 1;36m
+[1;36mColour 36 (Cyan) + Bold[0m
+
+Escape Sequence 92m
+[96mColour 96 (Bright Cyan)[0m

--- a/test/examples/errorlist/BoldOrBright.err.folded
+++ b/test/examples/errorlist/BoldOrBright.err.folded
@@ -1,0 +1,18 @@
+ 0 400   0   Escape Sequence 32m
+ 0 400   0   [32mColour 32 (Green)[0m
+ 0 400   0   
+ 0 400   0   Escape Sequence 1;32m
+ 0 400   0   [1;32mColour 32 (Green) + Bold[0m
+ 0 400   0   
+ 0 400   0   Escape Sequence 92m
+ 0 400   0   [92mColour 92 (Bright Green)[0m
+ 0 400   0   
+ 0 400   0   Escape Sequence 36m
+ 0 400   0   [36mColour 36 (Cyan)[0m
+ 0 400   0   
+ 0 400   0   Escape Sequence 1;36m
+ 0 400   0   [1;36mColour 36 (Cyan) + Bold[0m
+ 0 400   0   
+ 0 400   0   Escape Sequence 92m
+ 0 400   0   [96mColour 96 (Bright Cyan)[0m
+ 0 400   0   

--- a/test/examples/errorlist/BoldOrBright.err.styled
+++ b/test/examples/errorlist/BoldOrBright.err.styled
@@ -1,0 +1,17 @@
+{0}Escape Sequence 32m
+{23}[32m{42}Colour 32 (Green){23}[0m{40}
+{0}
+Escape Sequence 1;32m
+{23}[1;32m{50}Colour 32 (Green) + Bold{23}[0m{40}
+{0}
+Escape Sequence 92m
+{23}[92m{50}Colour 92 (Bright Green){23}[0m{40}
+{0}
+Escape Sequence 36m
+{23}[36m{46}Colour 36 (Cyan){23}[0m{40}
+{0}
+Escape Sequence 1;36m
+{23}[1;36m{54}Colour 36 (Cyan) + Bold{23}[0m{40}
+{0}
+Escape Sequence 92m
+{23}[96m{54}Colour 96 (Bright Cyan){23}[0m{40}


### PR DESCRIPTION
Updates lexer to treat the Bright Foreground (allow `ESC[90m` - `ESC[97m`) the same as Foreground Color + Bold (`ESC[1m` combined with `ESC[30m` - `ESC[37m`)

Add test cases

resolves #331 