### PR TITLE
Add includes and forward declarations

### DIFF
--- a/lexlib/LexAccessor.h
+++ b/lexlib/LexAccessor.h
@@ -8,6 +8,13 @@
 #ifndef LEXACCESSOR_H
 #define LEXACCESSOR_H
 
+#include "Sci_Position.h"
+#include <string>
+
+namespace Scintilla {
+class IDocument;
+}
+
 namespace Lexilla {
 
 enum class EncodingType { eightBit, unicode, dbcs };

--- a/lexlib/PropSetSimple.h
+++ b/lexlib/PropSetSimple.h
@@ -8,6 +8,8 @@
 #ifndef PROPSETSIMPLE_H
 #define PROPSETSIMPLE_H
 
+#include <string_view>
+
 namespace Lexilla {
 
 class PropSetSimple {


### PR DESCRIPTION
- IDocument forward declaration because used in LexAccessor
- string_view include because type is used in PropSetSimple
- Sci_Position include, because type used in the header