### PR TITLE
New syntax for Progress ABL typed annotations

### DIFF
--- a/lexers/LexProgress.cxx
+++ b/lexers/LexProgress.cxx
@@ -500,19 +500,29 @@ void SCI_METHOD LexerABL::Lex(Sci_PositionU startPos, Sci_Position length, int i
                sc.SetState(SCE_ABL_DEFAULT);
             }
          } else if (sc.ch == '@') {
-            if (!setClassName.Contains(sc.chNext) && sc.chNext != '@') {
-               // not an annotation - it might be something like: display "test" @ a
-               sc.SetState(SCE_ABL_DEFAULT);
-            }
-            else if (sc.chNext == '@') {
-               // @@typedannotation
-               sc.SetState(SCE_ABL_TYPEDANNOTATION);
-               sc.Forward();
-            }
-            else {
-               // @annotation
+            if (setClassName.Contains(sc.chNext) && visibleChars1 == 0) {
+               // @sourceannotation
                sc.SetState(SCE_ABL_ANNOTATION);
             }
+            else {
+               // not a source annotation - it might be something like: display "test" @ a
+               sc.SetState(SCE_ABL_OPERATOR);
+            }
+         }
+         else if (sc.ch == '[') {
+             if (setClassName.Contains(sc.chNext) && visibleChars1 == 0) {
+                // [typedannotation]
+                // The bracket is an operator and what follows is a typed annotation.
+                // Only the annotation's class name is styled as SCE_ABL_TYPEDANNOTATION;
+                // any properties that follow it are styled normally.
+                sc.SetState(SCE_ABL_OPERATOR);
+                sc.Forward();
+                sc.SetState(SCE_ABL_TYPEDANNOTATION);
+             }
+             else {
+                // not a typed annotation - it might be something like: a[b] = 12
+                sc.SetState(SCE_ABL_OPERATOR);
+             }
          } else if (isoperator(sc.ch)) {
             sc.SetState(SCE_ABL_OPERATOR);
             /*    This code allows highlight of handles. Alas, it would cause the phrase "last-event:function"

--- a/test/examples/progress/annotations.p
+++ b/test/examples/progress/annotations.p
@@ -1,19 +1,41 @@
 // @ used in the non-annotation sense
 display "test" @ field.
 
+// [ used in the non-annotation sense
+a[b] = 12
+
 // source annotation examples
 @sourceannotation
-@source-annotation()
+	@source-annotation()
 @source_annotation(prop = "abc")
-@source#$%annotation(prop = "abc", prop2 = 123)
+  @source#$%annotation(prop = "abc", prop2 = 123)
 
-// typed source annotation examples
-@@sourceannotation
-@@source-annotation()
-@@source_annotation(prop = "abc")
-@@source#$%annotation(prop = "abc", prop2 = 123)
+// typed annotation examples
+[typedannotation]
+	[typed-annotation()]
+[typed_annotation(prop = "abc")]
+  [typed#$%annotation(prop = "abc", prop2 = 123)]
+[typedannotation(
+    prop = "abc",
+    prop2 = 123)]
+
+// we don't care if the property list is malformed; @ or [ followed by a class
+// name at the start of a line is always styled as an annotation
+@source_annotation(prop = "abc"
+[typed_annotation(prop = "abc", prop2 = 123]
+@source_annotation
+
+// not an annotation because it's not the first non-whitespace character
+bad   @notannotation
+  bad   [notannotation]
 
 // poorly formed annotations
-@@@ThreeAtSigns // first two @ signs are typed, next is not typed
+@@@ThreeAtSigns // the @s are all operators, no annotation on this line
 @name[containsbadcharacter // annotation style stops at bad character
-@@name[containsbadcharacter // typed annotation style stops at bad character
+[name[containsbadcharacter // typed annotation style stops at bad character
+[name/containsbadcharacter // typed annotation style stops at bad character
+[ typedannotation ] // can't have a space between [ and the class name
+
+// array reference on multiple lines
+a
+[b] = 12 // valid syntax but will be styled as an annotation; lesson: don't do that

--- a/test/examples/progress/annotations.p.folded
+++ b/test/examples/progress/annotations.p.folded
@@ -1,20 +1,41 @@
  0 400 400   // @ used in the non-annotation sense
  0 400 400   display "test" @ field.
  0 400 400   
+ 0 400 400   // [ used in the non-annotation sense
+ 0 400 400   a[b] = 12
+ 0 400 400   
  0 400 400   // source annotation examples
  0 400 400   @sourceannotation
- 0 400 400   @source-annotation()
+ 0 400 400   	@source-annotation()
  0 400 400   @source_annotation(prop = "abc")
- 0 400 400   @source#$%annotation(prop = "abc", prop2 = 123)
+ 0 400 400     @source#$%annotation(prop = "abc", prop2 = 123)
  0 400 400   
- 0 400 400   // typed source annotation examples
- 0 400 400   @@sourceannotation
- 0 400 400   @@source-annotation()
- 0 400 400   @@source_annotation(prop = "abc")
- 0 400 400   @@source#$%annotation(prop = "abc", prop2 = 123)
+ 0 400 400   // typed annotation examples
+ 0 400 400   [typedannotation]
+ 0 400 400   	[typed-annotation()]
+ 0 400 400   [typed_annotation(prop = "abc")]
+ 0 400 400     [typed#$%annotation(prop = "abc", prop2 = 123)]
+ 0 400 400   [typedannotation(
+ 0 400 400       prop = "abc",
+ 0 400 400       prop2 = 123)]
+ 0 400 400   
+ 0 400 400   // we don't care if the property list is malformed; @ or [ followed by a class
+ 0 400 400   // name at the start of a line is always styled as an annotation
+ 0 400 400   @source_annotation(prop = "abc"
+ 0 400 400   [typed_annotation(prop = "abc", prop2 = 123]
+ 0 400 400   @source_annotation
+ 0 400 400   
+ 0 400 400   // not an annotation because it's not the first non-whitespace character
+ 0 400 400   bad   @notannotation
+ 0 400 400     bad   [notannotation]
  0 400 400   
  0 400 400   // poorly formed annotations
- 0 400 400   @@@ThreeAtSigns // first two @ signs are typed, next is not typed
+ 0 400 400   @@@ThreeAtSigns // the @s are all operators, no annotation on this line
  0 400 400   @name[containsbadcharacter // annotation style stops at bad character
- 0 400 400   @@name[containsbadcharacter // typed annotation style stops at bad character
- 1 400 400   
+ 0 400 400   [name[containsbadcharacter // typed annotation style stops at bad character
+ 0 400 400   [name/containsbadcharacter // typed annotation style stops at bad character
+ 0 400 400   [ typedannotation ] // can't have a space between [ and the class name
+ 0 400 400   
+ 0 400 400   // array reference on multiple lines
+ 0 400 400   a
+ 0 400 400   [b] = 12 // valid syntax but will be styled as an annotation; lesson: don't do that

--- a/test/examples/progress/annotations.p.styled
+++ b/test/examples/progress/annotations.p.styled
@@ -1,19 +1,41 @@
 {12}// @ used in the non-annotation sense
-{2}display{0} {3}"test"{0} @ {7}field{6}.{0}
+{2}display{0} {3}"test"{0} {6}@{0} {7}field{6}.{0}
+
+{12}// [ used in the non-annotation sense
+{7}a{6}[{7}b{6}]{0} {6}={0} {1}12{0}
 
 {12}// source annotation examples
 {13}@sourceannotation{0}
-{13}@source-annotation{6}(){0}
+	{13}@source-annotation{6}(){0}
 {13}@source_annotation{6}({7}prop{0} {6}={0} {3}"abc"{6}){0}
-{13}@source#$%annotation{6}({7}prop{0} {6}={0} {3}"abc"{6},{0} {7}prop2{0} {6}={0} {1}123{6}){0}
+  {13}@source#$%annotation{6}({7}prop{0} {6}={0} {3}"abc"{6},{0} {7}prop2{0} {6}={0} {1}123{6}){0}
 
-{12}// typed source annotation examples
-{14}@@sourceannotation{0}
-{14}@@source-annotation{6}(){0}
-{14}@@source_annotation{6}({7}prop{0} {6}={0} {3}"abc"{6}){0}
-{14}@@source#$%annotation{6}({7}prop{0} {6}={0} {3}"abc"{6},{0} {7}prop2{0} {6}={0} {1}123{6}){0}
+{12}// typed annotation examples
+{6}[{14}typedannotation{6}]{0}
+	{6}[{14}typed-annotation{6}()]{0}
+{6}[{14}typed_annotation{6}({7}prop{0} {6}={0} {3}"abc"{6})]{0}
+  {6}[{14}typed#$%annotation{6}({7}prop{0} {6}={0} {3}"abc"{6},{0} {7}prop2{0} {6}={0} {1}123{6})]{0}
+{6}[{14}typedannotation{6}({0}
+    {7}prop{0} {6}={0} {3}"abc"{6},{0}
+    {7}prop2{0} {6}={0} {1}123{6})]{0}
+
+{12}// we don't care if the property list is malformed; @ or [ followed by a class
+// name at the start of a line is always styled as an annotation
+{13}@source_annotation{6}({7}prop{0} {6}={0} {3}"abc"{0}
+{6}[{14}typed_annotation{6}({7}prop{0} {6}={0} {3}"abc"{6},{0} {7}prop2{0} {6}={0} {1}123{6}]{0}
+{13}@source_annotation{0}
+
+{12}// not an annotation because it's not the first non-whitespace character
+{7}bad{0}   {6}@{7}notannotation{0}
+  {7}bad{0}   {6}[{7}notannotation{6}]{0}
 
 {12}// poorly formed annotations
-{14}@@{13}@ThreeAtSigns{0} {12}// first two @ signs are typed, next is not typed
+{6}@@@{7}ThreeAtSigns{0} {12}// the @s are all operators, no annotation on this line
 {13}@name{6}[{7}containsbadcharacter{0} {12}// annotation style stops at bad character
-{14}@@name{6}[{7}containsbadcharacter{0} {12}// typed annotation style stops at bad character
+{6}[{14}name{6}[{7}containsbadcharacter{0} {12}// typed annotation style stops at bad character
+{6}[{14}name{6}/{7}containsbadcharacter{0} {12}// typed annotation style stops at bad character
+{6}[{0} {7}typedannotation{0} {6}]{0} {12}// can't have a space between [ and the class name
+{0}
+{12}// array reference on multiple lines
+{7}a{0}
+{6}[{14}b{6}]{0} {6}={0} {1}12{0} {12}// valid syntax but will be styled as an annotation; lesson: don't do that


### PR DESCRIPTION
I work for Progress (the main maintainer of the Progress ABL lexer). We changed the syntax for typed annotations in the ABL language from @@name to [name]. The typed annotations feature hasn't shipped in any release of our product so this change doesn't break existing installations. The existing @name syntax for source (non-typed) annotations is unaffected.

An annotation must be the first non-whitespace characters on a line and the annotation's name must immediately follow the @ or [ symbol. For source annotations the @ and the name are both styled as SCE_ABL_ANNOTATION. For typed annotations only the name is styled as SCE_ABL_TYPEDANNOTATION; the opening [ and closing ] are styled as SCE_ABL_OPERATOR.

I updated annotations.p with positive and negative cases.